### PR TITLE
Changed open_file_from_s3 to catch no such key error.

### DIFF
--- a/pixels/stac.py
+++ b/pixels/stac.py
@@ -105,7 +105,10 @@ def open_file_from_s3(source_path):
     bucket = s3_path.split("/")[0]
     path = s3_path.replace(bucket + "/", "")
     s3 = boto3.client("s3")
-    data = s3.get_object(Bucket=bucket, Key=path)
+    try:
+        data = s3.get_object(Bucket=bucket, Key=path)
+    except s3.exceptions.NoSuchKey:
+        data = None
     return data
 
 


### PR DESCRIPTION
This is useful when we are not sure if the file already exists. So the function can be used as:

```python
data = open_file_from_s3(uri)
if not data:
   continue
else:
   ...
```