### PR TITLE
Fixed 1D and multiclass handling.

### DIFF
--- a/pixels/exceptions.py
+++ b/pixels/exceptions.py
@@ -28,3 +28,11 @@ class InvalidGeneratorConfig(PixelsException):
     """
 
     pass
+
+
+class InconsistentGeneratorDataException(PixelsException):
+    """
+    The data available to the generator is inconsistent.
+    """
+
+    pass


### PR DESCRIPTION
With local testing, this seems to fix the 1D case. But I hope I am not breaking the 3D case. So please review.

- Added print of config at generator initialization.
- Moved the to_categorical statement to end of get_data_from_index function
- Moved the "fill_dimensions" for y up so that it is always run
- Heavily simplified 1D case by raveling first and then doing the masking