### PR TITLE
Ensure no duplicates x paths get on the dictionary. Closes #306 .

### DIFF
--- a/pixels/stac.py
+++ b/pixels/stac.py
@@ -654,6 +654,9 @@ def get_and_write_raster_from_item(
         logger.warning(f"Error in parsing data in get_and_write_raster_from_item: {e}")
     # Build a intermediate index catalog for the full one.
     stac_catalog_path = str(x_cat.get_self_href())
+    # Ensure no duplicates get on the dictionary.
+    # Only a temporary solution since this whole pipeline is to change.
+    out_paths = list(np.unique(out_paths))
     catalog_dict = {
         f"pixels_id_{str(item.id)}": {
             "x_paths": out_paths,


### PR DESCRIPTION
Temporary solution for the duplicate paths. This part is to be rewritten.