### PR TITLE
Fix(stac): Handle key error when opening catalog as collection.

### DIFF
--- a/pixels/stac_utils.py
+++ b/pixels/stac_utils.py
@@ -41,11 +41,11 @@ def get_catalog_length(catalog_path):
     if catalog_path.startswith("s3"):
         STAC_IO.read_text_method = stac_s3_read_method
         STAC_IO.write_text_method = stac_s3_write_method
+    # Try opening link as collection. If this fails, try opening it as catalog.
     try:
         collection = pystac.Collection.from_file(catalog_path)
         size = len(collection.get_child_links())
-    except Exception as e:
-        sentry_sdk.capture_exception(e)
+    except KeyError:
         catalog = pystac.Catalog.from_file(catalog_path)
         size = len(catalog.get_item_links())
     return size


### PR DESCRIPTION
Second try to fix this. I tracked down the error to calculating a catalog length here https://github.com/tesselo/pixels/blob/main/pixels/stac_utils.py#L48

The get_catalog_length function opens both Collections and Catalogs using
try/except. I narrowed down the error to KeyError, but stopped tracking it
in Sentry.

Closes #326.