### PR TITLE
fix(prediction): ensure usage of s3 io functions during stac item creation

### DIFF
--- a/pixels/generator/stac.py
+++ b/pixels/generator/stac.py
@@ -156,7 +156,8 @@ def list_files_in_s3(uri, filetype="tif"):
         s3 = boto3.client("s3")
         paginator = s3.get_paginator("list_objects_v2")
         theObjs = paginator.paginate(Bucket=bucket, Prefix=key)
-        mult_obj = [ob["Contents"] for ob in theObjs]
+        # Get list of objects if thre are any.
+        mult_obj = [ob["Contents"] for ob in theObjs if "Contents" in ob]
         list_obj = []
         for obj in mult_obj:
             ob = [
@@ -709,6 +710,10 @@ def build_catalog_from_items(
         items_list = list_files_in_s3(path_to_items, filetype="_item.json")
     else:
         items_list = glob.glob(f"{path_to_items}/*{filetype}", recursive=True)
+    # Abort here if there are no items to create a catalog.
+    if not items_list:
+        logger.warning(f"No items found to create catalog for {path_to_items}.")
+        return
     catalog = pystac.Catalog(id=id_name, description=description)
     for item_path in items_list:
         item = pystac.read_file(item_path)

--- a/pixels/generator/stac_training.py
+++ b/pixels/generator/stac_training.py
@@ -1,4 +1,3 @@
-import datetime
 import io
 import json
 import os
@@ -10,7 +9,6 @@ import sentry_sdk
 import structlog
 import tensorflow as tf
 import tensorflow_addons
-from dateutil import parser
 from rasterio import Affine
 
 import pixels.generator.stac as stc
@@ -670,32 +668,3 @@ def predict_function_batch(
                 out_path_tif = f"{out_path}_{date_list[image_count]}.tif"
                 _save_and_write_tif(out_path_tif, prediction[image_count], meta)
                 image_count = image_count + 1
-        # Build the corresponding pystac item.
-        try:
-            cat = pystac.Catalog.from_file(
-                dtgen.collection_catalog[catalog_id]["stac_catalog"]
-            )
-            for itt in cat.get_items():
-                it = itt
-                break
-            id_raster = catalog_id
-            datetime_var = str(datetime.datetime.now().date())
-            datetime_var = parser.parse(datetime_var)
-            footprint = it.geometry
-            bbox = it.bbox
-            path_item = out_path_tif
-            aditional_links = {"x_catalog": x_path, "model_used": model_uri}
-            href_path = os.path.join(predict_path, "stac", f"{id_raster}_item.json")
-            create_pystac_item(
-                id_raster,
-                footprint,
-                bbox,
-                datetime_var,
-                meta,
-                path_item,
-                aditional_links,
-                href_path,
-            )
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
-            logger.warning(f"Error in parsing data in predict_function_batch: {e}")


### PR DESCRIPTION
This fixes two sentry errors at once. The one directly here, and downstream the create catalog function.

So the predictions jobs should not fail anymore.

Closes #335