### PR TITLE
fix(mosaic): use nearest neighbor resampling for SCL band

### DIFF
--- a/pixels/const.py
+++ b/pixels/const.py
@@ -127,6 +127,8 @@ L4_L5_BANDS = ["B1", "B2", "B3", "B4", "B5", "B6", "B7"]
 L4_L5_BANDS_MSS = ["B1", "B2", "B3", "B4"]
 L1_L2_L3_BANDS = ["B4", "B5", "B6", "B7"]
 
+DISCRETE_BANDS = ["SCL"]
+
 # Bands for composite mode.
 S2_BANDS_REQUIRED_FOR_COMPOSITES = ["B02", "B03", "B04", "B08", "B8A", "B11", "B12"]
 

--- a/pixels/mosaic.py
+++ b/pixels/mosaic.py
@@ -8,6 +8,7 @@ from rasterio.errors import RasterioIOError
 
 from pixels.clouds import pixels_mask
 from pixels.const import (
+    DISCRETE_BANDS,
     LANDSAT_1_LAUNCH_DATE,
     NODATA_VALUE,
     S2_BANDS_REQUIRED_FOR_COMPOSITES,
@@ -131,7 +132,15 @@ def latest_pixel(
             first_end_date = str(items[0]["sensing_time"].date())
         # Prepare band list.
         band_list = [
-            (item["bands"][band], geojson, scale, False, False, False, None)
+            (
+                item["bands"][band],
+                geojson,
+                scale,
+                True if band in DISCRETE_BANDS else False,
+                False,
+                False,
+                None,
+            )
             for band in bands
         ]
 
@@ -458,7 +467,15 @@ def composite(
             first_end_date = str(items[0]["sensing_time"].date())
         # Prepare band list.
         band_list = [
-            (item["bands"][band], geojson, scale, False, False, False, None)
+            (
+                item["bands"][band],
+                geojson,
+                scale,
+                True if band in DISCRETE_BANDS else False,
+                False,
+                False,
+                None,
+            )
             for band in bands_copy
         ]
 


### PR DESCRIPTION
The SCL band is discrete, so bilinear interpolation does not make sense. For discrete layers, we need to use nearest neighbor resampling.