### PR TITLE
chore(batch): unpin and upgrade fiona dependency

### DIFF
--- a/batch/docker/requirements.in
+++ b/batch/docker/requirements.in
@@ -9,7 +9,7 @@
 awscli==1.19.13
 boto3==1.17.13
 matplotlib==3.3.4
-Fiona==1.8.18
+Fiona
 SQLAlchemy==1.3.23
 pg8000==1.16.5
 mercantile==1.1.6

--- a/batch/docker/requirements.txt
+++ b/batch/docker/requirements.txt
@@ -52,7 +52,7 @@ cycler==0.10.0
     # via matplotlib
 docutils==0.15.2
     # via awscli
-fiona==1.8.18
+fiona==1.8.20
     # via
     #   -r ./batch/docker/requirements.in
     #   geopandas


### PR DESCRIPTION
We use FlatGeobuf, but this is a more recent filetype. Need to upgrade fiona to write these files.

`fiona.errors.DriverError: FlatGeobuf driver requires at least GDAL 3.1.3 for mode 'w', Fiona was compiled against: 2.4.4`