### PR TITLE
Fetch all items on execute_query

### DIFF
--- a/pixels/search.py
+++ b/pixels/search.py
@@ -94,7 +94,6 @@ def search_data(
         geojson, start, end, platforms, maxcloud, scene, sensor, level, limit, sort
     )
 
-    # Transform ResultProxy into json.
     scenes_result = get_bands([dict(row) for row in db_result], level=level)
 
     # Convert cloud cover into float to allow json serialization of the output.
@@ -186,7 +185,7 @@ def execute_query(
             links=", links",
         )
         with pxsearch_db_engine.connect() as connection:
-            yield connection.execute(formatted_query)
+            yield connection.execute(formatted_query).fetchall()
     else:
         formatted_query = query.format(
             xmin=xmin,
@@ -199,7 +198,7 @@ def execute_query(
             links="",
         )
         with pixels_db_engine.connect() as connection:
-            yield connection.execute(formatted_query)
+            yield connection.execute(formatted_query).fetchall()
 
 
 def build_query(start, end, platforms, maxcloud, scene, sensor, level, limit, sort):


### PR DESCRIPTION
Solves https://sentry.io/organizations/tesselo/issues/2778579321/?project=5760850

Why it was working previously? We don't know, maybe the engine execute ResultQuery is directly suscriptable, maybe not. But if we explicitly call to fetchall, it should work for all cases.