### PR TITLE
Generator split fix

### DIFF
--- a/pixels/generator/generator.py
+++ b/pixels/generator/generator.py
@@ -268,7 +268,7 @@ class DataGenerator(keras.utils.Sequence):
         """
         Seting class id list based on existing catalog dictionary.
         """
-        if self.usage_type == GENERATOR_MODE_PREDICTION:
+        if self.usage_type in [GENERATOR_MODE_PREDICTION, GENERATOR_MODE_TRAINING]:
             self.training_percentage = self.split
         # The ids are the names of each image collection.
         self.original_id_list = list(self.collection_catalog.keys())


### PR DESCRIPTION
added an internal forcing of training percentage = split in training mode. This forcing was done outside the generator in the pipeline. but is more logical to have this behavior always. Making split always the variable that chooses the size. No changes in P2 behavior 