### PR TITLE
fix(prediction): force shuffle to false

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -159,7 +159,7 @@ Sentinel-2, and 65535 for Landsat-8.
 
 Determines if the available data shall be shuffled randomly before each epoch.
 Randomizing the order of the input data helps the model converge faster during
-training. Default: True.
+training. This is set to false if not in training mode. Default: True.
 
 ### Data storage
 

--- a/pixels/generator/generator.py
+++ b/pixels/generator/generator.py
@@ -95,6 +95,8 @@ class DataGenerator(keras.utils.Sequence):
         self.usage_type = usage_type
         self.normalization = normalization
         self.shuffle = shuffle
+        if self.usage_type != GENERATOR_MODE_TRAINING:
+            self.shuffle = False
 
         # Multiclass transform.
         self.class_definitions = class_definitions


### PR DESCRIPTION
this makes sure every batch does not get the same id, same issue befores with random seed