### PR TITLE
refactor(mosaic): replace pool by threadpool

### DIFF
--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -150,7 +150,7 @@ class TestMosaic(unittest.TestCase):
             bands=["B01", "B02"],
             clip=False,
             level="L2A",
-            pool_size=1,
+            pool_size=5,
         )
         self.assertEqual(
             dates, ["2020-01-20", "2020-01-20", "2020-01-20", "2020-01-20"]


### PR DESCRIPTION
AWS lambda does not allow multi-processing. With this, we can try to parallelize the on-the-fly rendering on lambda and see how fast it gets.