### PR TITLE
Use our GitHub release action

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -68,3 +68,13 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Sentry Release
+        uses: tesselo/release-action@main
+        with:
+          sentry_project: pixels
+          sentry_environment: 'production'
+          sentry_release: ${{ github.sha }}
+          code_dir: 'pixels'
+        env:
+          SENTRY_ORG: 'tesselo'
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
The previous attempt for releasing in Sentry with giges finally worked, but we want that to happen in all our projects, so the GitHub action was born. Let's use it everywhere!

Asana Context: https://app.asana.com/0/1200802773613549/1201674203358872/f