### PR TITLE
fix keyword in multiprocessing calling

### DIFF
--- a/pixels/generator/stac.py
+++ b/pixels/generator/stac.py
@@ -262,7 +262,7 @@ def parse_prediction_area(
             catalog,
             tiles.crs,
         ],
-        ite_size=len(tiles),
+        iterator_size=len(tiles),
     )
     catalog.add_items(result_parse)
     # Normalize paths inside catalog.


### PR DESCRIPTION
The caller to the vector multiprocess in parsing was with a old argument name. Fixed it