### PR TITLE
fix moving window end on prediction

### DIFF
--- a/pixels/generator/stac_training.py
+++ b/pixels/generator/stac_training.py
@@ -550,14 +550,14 @@ def predict_function_batch(
                         jump_pad_i_f = jump_pad
                         if i == 0:
                             jump_pad_i_i = 0
-                        if big_square_width - i < jump_width:
+                        if big_square_width - i <= jump_width:
                             jump_pad_i_f = 0
                         if big_square_width - i < width:
                             jump_pad_i_f = 0
                             jump_pad_i_i = 0
                         if j == 0:
                             jump_pad_j_i = 0
-                        if big_square_height - j < jump_height:
+                        if big_square_height - j <= jump_height:
                             jump_pad_j_f = 0
                         if big_square_height - j < height:
                             jump_pad_j_f = 0


### PR DESCRIPTION
While doing the moving window, if the last window was the exact same size remaining in the image it would still pad that end. Changed to make that pad to zero if the moving window size is equal to leftover.

Finish task: https://app.asana.com/0/1200802773613549/1201849750435153/f

Fixes stripes on end of every tile in predictions

PS: I know a lot of refactoring and renaming where should take place, but can we leave that to another point in time?? :fox_face: 