### PR TITLE
Do not pad day with 0 in cog_to_jp2_bucket

### DIFF
--- a/pixels/utils.py
+++ b/pixels/utils.py
@@ -345,9 +345,9 @@ def cog_to_jp2_bucket(source: str) -> str:
     """
     parts = source.split("/")
 
-    day = parts[-2].split("_")[2][-2:]
+    day = int(parts[-2].split("_")[2][-2:])
     band = parts[-1].split(".tif")[0]
-    scene_count = parts[-2].split("_")[3]
+    scene_count = int(parts[-2].split("_")[3])
     resolution = S2_BAND_RESOLUTIONS[band]
 
     return f"s3://sentinel-s2-l2a/tiles/{'/'.join(parts[4:-2])}/{day}/{scene_count}/R{resolution}m/{band}.jp2"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,3 +160,11 @@ class TestUtils(unittest.TestCase):
         )
 
         self.assertEqual(expected, transformed)
+
+        expected = "s3://sentinel-s2-l2a/tiles/31/N/HA/2019/10/7/0/R20m/B11.jp2"
+        transformed = cog_to_jp2_bucket(
+            "https://sentinel-cogs.s3.us-west-2.amazonaws.com/"
+            "sentinel-s2-l2a-cogs/31/N/HA/2019/10/S2B_31NHA_20191007_0_L2A/B11.tif"
+        )
+
+        self.assertEqual(expected, transformed)


### PR DESCRIPTION
This fixes this sentry found exception: https://sentry.io/organizations/tesselo/issues/3027541804/?project=5760850

The days are 0 padded in the COG bucket, but not in the JP2 path