### PR TITLE
Make the yielded tuple explicit in unwrap_arguments

### DIFF
--- a/pixels/utils.py
+++ b/pixels/utils.py
@@ -375,7 +375,7 @@ def unwrap_arguments(variable_arguments: List[Iterable], static_arguments: List[
             (var_argA_1, var_argB_1, ..., static1, static2, ...)
     """
     for args in zip(*variable_arguments):
-        yield *args, *static_arguments
+        yield (*args, *static_arguments)
 
 
 def run_starmap_multiprocessing(


### PR DESCRIPTION
Let's make this tuple explicit in order to solve this bug: https://sentry.io/organizations/tesselo/issues/3027673420/?project=5760850&query=is%3Aunresolved

It was explicit before, but some code linters were complaining about the thing being redundant. Well, it might not be completely redundant after all...