### PR TITLE
Abort prediction parsing on shapefile loading errors

### DIFF
--- a/pixels/generator/stac.py
+++ b/pixels/generator/stac.py
@@ -213,7 +213,7 @@ def parse_prediction_area(
         tiles = gp.read_file(data)
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        logger.warning(f"Error in reading from shapefile: {e}")
+        raise PixelsException(f"Error in reading from shapefile: {e}")
     file_format = source_path.split(".")[-1]
     id_name = os.path.split(source_path)[-1].replace(f".{file_format}", "")
     catalog = pystac.Catalog(id=id_name, description=description)


### PR DESCRIPTION
This will avoid continuing the flow for the non defined tiles variable on shapefile loading error:

https://sentry.io/organizations/tesselo/issues/3044068483/?project=5760850