### PR TITLE
refactor(pixel_stack): disable retrieve pool

### DIFF
--- a/pixels/mosaic.py
+++ b/pixels/mosaic.py
@@ -289,7 +289,7 @@ def pixel_stack(
     if not isinstance(platforms, (list, tuple)):
         platforms = [platforms]
 
-    retrieve_pool = True
+    retrieve_pool = False
 
     if mode == "all" or interval == "all":
         # For all mode, the date range is constructed around each scene, and


### PR DESCRIPTION
This will disable the current threading retrieve for pixel_stack. Hopefully will solve the compositing errors that we are finding, and the related https://sentry.io/organizations/tesselo/issues/2956867296/?project=5760850 errors due to using many JP2 file.