### PR TITLE
refactor(retrieve): log rasterio open fails without sending to sentry

### DIFF
--- a/pixels/retrieve.py
+++ b/pixels/retrieve.py
@@ -1,6 +1,5 @@
 import numpy
 import rasterio
-import sentry_sdk
 import structlog
 from rasterio.crs import CRS
 from rasterio.errors import RasterioIOError
@@ -72,8 +71,9 @@ def retrieve(
     try:
         src = rasterio.open(source)
     except RasterioIOError as e:
-        sentry_sdk.capture_exception(e)
+        logger.warning(f"Rasterio open failed for {source}: {str(e)}")
         if is_sentinel_cog_bucket(source):
+            logger.warning(f"Retrying retrieve for {source} in the JP2 bucket")
             return retrieve(
                 cog_to_jp2_bucket(source),
                 geojson,


### PR DESCRIPTION
This one is important, we almost reach the limit of errors in sentry due to the SPAM nature of the failures in the COG bucket that we are having now and we will not be notified about other errors if we reach the limit.