### PR TITLE
Execute runpixels with the default python version in the system

### DIFF
--- a/batch/runpixels.py
+++ b/batch/runpixels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python
 """
 Execute a function from the pixels package from the commandline.
 """


### PR DESCRIPTION
This will allow to run runpixels locally