### PR TITLE
chore(batch): unpin and upgrade libraries

### DIFF
--- a/batch/docker/requirements.in
+++ b/batch/docker/requirements.in
@@ -20,8 +20,6 @@ click
 pygeos
 h5py==2.10.0
 tqdm
-
-# The following libraries require python3.8
-numpy<1.19
-pandas<1.4.0
-urllib3<1.26
+numpy
+pandas
+urllib3

--- a/batch/docker/requirements.txt
+++ b/batch/docker/requirements.txt
@@ -8,20 +8,20 @@
 
 affine==2.3.0
     # via rasterio
-asn1crypto==1.4.0
+asn1crypto==1.5.1
     # via scramp
 attrs==21.4.0
     # via
     #   fiona
     #   jsonschema
     #   rasterio
-awscli==1.22.67
+awscli==1.22.75
     # via -r ./batch/docker/requirements.in
 backoff==1.11.1
     # via -r ./batch/docker/requirements.in
-boto3==1.21.12
+boto3==1.21.20
     # via -r ./batch/docker/requirements.in
-botocore==1.24.12
+botocore==1.24.20
     # via
     #   awscli
     #   boto3
@@ -69,13 +69,13 @@ jmespath==0.10.0
     #   botocore
 jsonschema==3.2.0
     # via -r ./batch/docker/requirements.in
-kiwisolver==1.3.2
+kiwisolver==1.4.0
     # via matplotlib
 matplotlib==3.3.4
     # via -r ./batch/docker/requirements.in
 munch==2.5.0
     # via fiona
-numpy==1.22.2
+numpy==1.22.3
     # via
     #   -r ./batch/docker/requirements.in
     #   h5py
@@ -85,7 +85,9 @@ numpy==1.22.2
     #   rasterio
     #   snuggs
 pandas==1.4.1
-    # via geopandas
+    # via
+    #   -r ./batch/docker/requirements.in
+    #   geopandas
 pg8000==1.24.1
     # via -r ./batch/docker/requirements.in
 pillow==9.0.1
@@ -126,7 +128,7 @@ s3transfer==0.5.2
     #   boto3
 scramp==1.4.1
     # via pg8000
-sentry-sdk==1.5.6
+sentry-sdk==1.5.7
     # via
     #   -r ./batch/docker/requirements.in
     #   structlog-sentry
@@ -141,7 +143,7 @@ six==1.16.0
     #   python-dateutil
 snuggs==1.4.7
     # via rasterio
-sqlalchemy==1.4.31
+sqlalchemy==1.4.32
     # via -r ./batch/docker/requirements.in
 structlog==21.5.0
     # via -r ./batch/docker/requirements.in
@@ -153,8 +155,9 @@ tqdm==4.63.0
     # via -r ./batch/docker/requirements.in
 typeguard==2.13.3
     # via tensorflow-addons
-urllib3==1.26.8
+urllib3==1.26.9
     # via
+    #   -r ./batch/docker/requirements.in
     #   botocore
     #   sentry-sdk
 

--- a/batch/docker/tensorflow_requirements.txt
+++ b/batch/docker/tensorflow_requirements.txt
@@ -36,7 +36,7 @@ h5py==3.6.0
     # via tensorflow
 idna==3.3
     # via requests
-importlib-metadata==4.11.2
+importlib-metadata==4.11.3
     # via markdown
 keras==2.7.0
     # via tensorflow
@@ -46,7 +46,7 @@ libclang==13.0.0
     # via tensorflow
 markdown==3.3.6
     # via tensorboard
-numpy==1.22.2
+numpy==1.22.3
     # via
     #   h5py
     #   keras-preprocessing
@@ -100,7 +100,7 @@ termcolor==1.1.0
     # via tensorflow
 typing-extensions==4.1.1
     # via tensorflow
-urllib3==1.26.8
+urllib3==1.26.9
     # via requests
 werkzeug==2.0.3
     # via tensorboard
@@ -109,7 +109,7 @@ wheel==0.37.1
     #   astunparse
     #   tensorboard
     #   tensorflow
-wrapt==1.13.3
+wrapt==1.14.0
     # via tensorflow
 zipp==3.7.0
     # via importlib-metadata


### PR DESCRIPTION
We are now running Python 3.8 so we can unpin numpy, pandas, and urllib3.

Refs: https://github.com/tesselo/pixels/pull/492