### PR TITLE
fix(training): allow for addon loss in load_model

### DIFF
--- a/pixels/generator/stac_training.py
+++ b/pixels/generator/stac_training.py
@@ -128,7 +128,7 @@ def load_existing_model_from_file(
         f = h5py.File(bio_, "r")
         model_uri = f
     # Construct model object.
-    if hasattr(tf.keras.losses, loss):
+    if hasattr(tf.keras.losses, loss) or hasattr(tfa.losses, loss):
         model = tf.keras.models.load_model(model_uri)
     elif loss in ALLOWED_CUSTOM_LOSSES:
         # Handle custom loss functions when loading the model.


### PR DESCRIPTION
In the load keras model function, allow for use of addons loss function.

fixes:
https://sentry.io/organizations/tesselo/issues/3144270746/?project=5760850&referrer=slack


Tested locally, result:
s3://pxapi-media-dev/prediction/94542150-d4c3-4bef-bb51-31b6f41adf89/predictions/item_pixels_id_0.tif