### PR TITLE
make resnet moving window on real data

### DIFF
--- a/pixels/generator/generator.py
+++ b/pixels/generator/generator.py
@@ -594,8 +594,8 @@ class DataGenerator(keras.utils.Sequence, BoundLogger):
         )
         y_pixels = []
         x_train_imgs = []
-        for h in range(self.height * self.upsampling):
-            for w in range(self.width * self.upsampling):
+        for h in range(pad_size, self.height * self.upsampling):
+            for w in range(pad_size, self.width * self.upsampling):
                 if Y is not None:
                     y_pixel = Y[h, w, :]
                     if np.all(y_pixel == self.y_nan_value):


### PR DESCRIPTION
This wil make the resnet moving window just start when the window is only with real data inside (no padding), and finish before reaching the padding also.

if a square has 13 pixels, and the moving window is 3 pixels.
it will start at index (1,1) where all the surrounding is real data.
it will end at index (11,11), where it wont catch padding yet.

Works for every moving window frame