### PR TITLE
Ignore nan class

### DIFF
--- a/pixels/generator/losses.py
+++ b/pixels/generator/losses.py
@@ -21,10 +21,11 @@ def nan_mean_squared_error_loss(nan_value=np.nan):
     return loss
 
 
-def nan_categorical_crossentropy_loss(nan_value=np.nan):
+def nan_categorical_crossentropy_loss(nan_value=np.nan, class_with_nan=None):
     # Create a loss function
     def loss(y_true, y_pred):
-        indices = tf.where(tf.not_equal(y_true, nan_value))
+        sparse = tf.math.argmax(y_true, axis=-1)
+        indices = tf.where(tf.not_equal(sparse, class_with_nan))
         return tf.keras.losses.categorical_crossentropy(
             tf.gather_nd(y_true, indices), tf.gather_nd(y_pred, indices)
         )


### PR DESCRIPTION
This fix on nan_categorical_crossentropy_loss will allow for use of categorical data with nan values to be used without constrain.

It assumes that the nan class is the one given (set in fit args), by the generator it is always the last one!
Makes loss function only on valid pixels