### PR TITLE
Prediction size

### DIFF
--- a/pixels/generator/prediction_utils.py
+++ b/pixels/generator/prediction_utils.py
@@ -445,7 +445,7 @@ def merge_prediction(generator_config_uri):
             outfile,
             command_args=command_args,
             dtype="uint8",
-            mem_limit=10,
+            mem_limit=1,
         )
 
     if predict_path.startswith("s3"):


### PR DESCRIPTION
Argmax calc is failing in some prediction. Changed mem chunck size to 1.
I tested the fail with trying to increase the job size but it had the same error. So changing chunch size might do the trick.