### PR TITLE
Predictions merge memory leak

### DIFF
--- a/pixels/generator/prediction_utils.py
+++ b/pixels/generator/prediction_utils.py
@@ -432,6 +432,7 @@ def merge_prediction(generator_config_uri):
             no_data=raster_meta["nodata"],
             merger_folder=merger_files_folder,
         )
+    predictions_bbox = None
     if extract_probabilities:
         logger.info("Extrating probabilities. Building class raster.")
         calc = "argmax"


### PR DESCRIPTION
Making the chunks smaller also resulted in a OOM.
Trying to increase chunck memory instead. And empty bbox variable.

Also I tried decreasing memory in the wrong place...
So if this fails probably will try again decreasing.