### PR TITLE
Reuse of dates messed type

### DIFF
--- a/pixels/generator/stac.py
+++ b/pixels/generator/stac.py
@@ -532,7 +532,7 @@ def existing_timesteps_range(timesteps, existing_files):
         else:
             start = [min(f[0]) for f in time_bubbles]
             end = [max(f[-1]) for f in time_bubbles]
-    return start, end
+    return str(start), str(end)
 
 
 def get_and_write_raster_from_item(


### PR DESCRIPTION
Make the call to timeseries_steps always have strings as the parameters.
solves:
https://sentry.io/organizations/tesselo/issues/3222950877/?project=5760850&query=is%3Aunresolved#exception