### PR TITLE
feat(validator): disallow extra field input

### DIFF
--- a/pixels/validators.py
+++ b/pixels/validators.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional, Union
 
 from geojson_pydantic.features import FeatureCollection
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, Extra, root_validator, validator
 from rasterio.crs import CRS
 from rasterio.errors import CRSError
 
@@ -69,7 +69,7 @@ class FeatureCollectionCRS(FeatureCollection):
         return v
 
 
-class PixelsConfigValidator(BaseModel):
+class PixelsConfigValidator(BaseModel, extra=Extra.forbid):
     dynamic_dates_step: int = 1
     start: Optional[str]
     end: Optional[str]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -171,3 +171,9 @@ class TestValidators(unittest.TestCase):
         config = complete_valid_config()
         config["mode"] = "all"
         PixelsConfigValidator(**config)
+
+    def test_extra_field_not_allowed(self):
+        config = complete_valid_config()
+        config["invalid"] = True
+        with self.assertRaises(ValueError):
+            PixelsConfigValidator(**config)


### PR DESCRIPTION
This makes the validator stricter. Currently it was possible
to pass data that was not registered as a field in the class.

The new `composite_method` argument was passed to the class but simply dropped silently.

Now if we try to pass new fields that were not added to the validator class, it will complain.