### PR TITLE
Pooling for bands

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -131,9 +131,14 @@ process.
 The `clip` parameter is a boolean, determining if the image slices should be
 clipped against the input geometries.
 
-The `pool_size` parameter determines how many images can be collected in
+The `pool_size` parameter determines how many image dates can be collected in
 parallel on the backend. This is still experimental and should be used with
 caution. Specifying `pool_size` to `1` is the safest option.
+
+An alternative way of parallelizing the collections is getting all the bands in
+parallel, instead of getting the dates in parallel. This can be achieved by using
+the `pool_bands` boolean parameter. This can not be used in combination with date
+pooling at the same time. Defaults to `False`.
 
 The `overwrite` parameter is a boolean, determining if the images already downloaded
 are overwriten. It defaults to False.

--- a/pixels/validators.py
+++ b/pixels/validators.py
@@ -85,6 +85,7 @@ class PixelsConfigValidator(BaseModel, extra=Extra.forbid):
     clip: bool = True
     maxcloud: int = 20
     pool_size: int = 0
+    pool_bands: bool = False
     platforms: Union[LandsatPlatform, SentinelPlatform, list, tuple]
     level: Optional[Union[SentinelLevelOption, LandsatLevelOption]]
     bands: Union[list, tuple]
@@ -143,3 +144,8 @@ class PixelsConfigValidator(BaseModel, extra=Extra.forbid):
         if v and not values.get("mode") == ModeOption.composite:
             raise ValueError("Composite method is only used in composite mode.")
         return v
+
+    @validator("pool_bands")
+    def check_pool_bands(cls, v, values):
+        if v and values.get("pool_size") > 1:
+            raise ValueError("Bands pooling can not be combined with dates pooling")

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -152,7 +152,7 @@ class TestMosaic(unittest.TestCase):
             scale=500,
             bands=["B01", "B02"],
             clip=False,
-            pool=True,
+            pool_bands=True,
         )
         self.assertEqual(first_end_date, "2020-01-20")
         expected = [[[2956, 2996], [7003, 7043]], [[2956, 2996], [7003, 7043]]]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -190,3 +190,10 @@ class TestValidators(unittest.TestCase):
         config["composite_method"] = "FULL"
         with self.assertRaises(ValueError):
             PixelsConfigValidator(**config)
+
+    def test_pooling_invalid(self):
+        config = complete_valid_config()
+        config["pool_size"] = 2
+        config["pool_bands"] = True
+        with self.assertRaises(ValueError):
+            PixelsConfigValidator(**config)


### PR DESCRIPTION
Enabling pooling for the retrieval of bands is a good alternative for collections with little timesteps.

For one month composites, there is only one time step, but many bands for every image. So we can parallelize the band retrieval.