### PR TITLE
fix(utils): remove loop from tag writing

### DIFF
--- a/pixels/utils.py
+++ b/pixels/utils.py
@@ -322,8 +322,7 @@ def write_raster(
     if out_path:
         with rasterio.open(out_path, "w", **out_meta) as dst:
             # Set the given metadata tags.
-            for key, val in tags.items():
-                dst.update_tags(**tags)
+            dst.update_tags(**tags)
             dst.write(data)
             try:
                 dst.build_overviews(factors, resampling)


### PR DESCRIPTION
Might be related to "Error in saving raster, building overviews: TIFFWriteDirectoryTagData:IO error writing tag data"

https://eu-central-1.console.aws.amazon.com/batch/home?region=eu-central-1#jobs/detail/4c9cf864-ce99-478e-881e-d238e0aa637d