### PR TITLE
Refactor load models

### DIFF
--- a/pixels/const.py
+++ b/pixels/const.py
@@ -4,6 +4,27 @@ INTEGER_NODATA_VALUE = 255
 FLOAT_NODATA_VALUE = -9999
 BBOX_PIXEL_WITH_HEIGHT_TOLERANCE = 0.001
 
+NAN_VALUE_LOSSES = [
+    "nan_mean_squared_error_loss",
+    "nan_root_mean_squared_error_loss",
+    "stretching_error_loss",
+    "square_stretching_error_loss",
+    "root_mean_squared_error_loss_more_or_less",
+]
+
+ALLOWED_CUSTOM_LOSSES = NAN_VALUE_LOSSES + [
+    "square_stretching_error_loss",
+    "nan_categorical_crossentropy_loss",
+    "root_mean_squared_error",
+    "nan_categorical_crossentropy_loss_drop_classe",
+]
+
+
+EVALUATION_PERCENTAGE_LIMIT = 0.2
+EVALUATION_SAMPLE_LIMIT = 2000
+TRAIN_WITH_ARRAY_LIMIT = 1e8
+
+
 LS_BANDS = [
     "B1",
     "B2",

--- a/pixels/generator/losses.py
+++ b/pixels/generator/losses.py
@@ -21,7 +21,7 @@ def nan_mean_squared_error_loss(nan_value=np.nan):
     return loss
 
 
-def nan_categorical_crossentropy_loss(nan_value=np.nan, class_with_nan=None):
+def nan_categorical_crossentropy_loss(class_with_nan=None):
     # Create a loss function
     def loss(y_true, y_pred):
         sparse = tf.math.argmax(y_true, axis=-1)
@@ -34,7 +34,7 @@ def nan_categorical_crossentropy_loss(nan_value=np.nan, class_with_nan=None):
     return loss
 
 
-def nan_categorical_crossentropy_loss_drop_classe(nan_value=np.nan, class_to_ignore=0):
+def nan_categorical_crossentropy_loss_drop_classe(class_to_ignore=0):
     # Create a loss function to ignore classes on one-hot scheme, can be input as a list or an int.
     if isinstance(class_to_ignore, int):
         class_to_ignore = [class_to_ignore]
@@ -63,13 +63,16 @@ def nan_root_mean_squared_error_loss(nan_value=np.nan):
     return loss
 
 
-def nan_root_mean_squared_error_loss_more_or_less(nan_value=np.nan, less=True):
-    # Create a loss function that only sees <= or >= than nan_value.
+def root_mean_squared_error_loss_more_or_less(value=0, less=True, nan_value=None):
+    # Create a loss function that only sees <= or >= than value.
     def loss(y_true, y_pred):
+        valid_indices = tf.where(tf.not_equal(y_true, nan_value))
         if less:
-            indices = tf.where(tf.less_equal(y_true, nan_value))
+            indices = tf.where(tf.less_equal(y_true, value))
         else:
-            indices = tf.where(tf.greater_equal(y_true, nan_value))
+            indices = tf.where(tf.greater_equal(y_true, value))
+        indices = tf.concat([indices, valid_indices], axis=0)
+        indices = tf.unique(indices).idx
         return root_mean_squared_error(
             tf.gather_nd(y_true, indices), tf.gather_nd(y_pred, indices)
         )


### PR DESCRIPTION
Refactor and restructure of the way we load models and loss function in P2.
Module by steps and functions the loading of models and loss functions.

This will solve:
https://sentry.io/organizations/tesselo/issues/3260424188/?project=5760850&referrer=slack

This will change something in the usage of P2. So far we have been calling our loss functions by the keras function name, but now we need to start calling it by the class name. If the loss functions is from addons or from our own, then there is no issue here.
See differences in here:
https://keras.io/api/losses/

example:
we call: 
`binary_crossentropy` but now it should be `BinaryCrossentropy`