### PR TITLE
Do not break everything on training logging

### DIFF
--- a/pixels/generator/stac_training.py
+++ b/pixels/generator/stac_training.py
@@ -223,7 +223,7 @@ class LogProgress(tf.keras.callbacks.Callback):
     def _log_status(self, state, epoch, logs):
         logs = logs or {}
         logger.info(
-            state, current_epoch=epoch + 1, all_epochs=self.param["epochs"], **logs
+            state, current_epoch=epoch + 1, all_epochs=self.params["epochs"], **logs
         )
 
     def on_epoch_begin(self, epoch, logs=None):


### PR DESCRIPTION
This huge PR fixes https://sentry.io/organizations/tesselo/issues/3281479989/?project=5760850

I think that my virtual cat girlfriend stepped onto the keyboard when I opened the last PR, that is the reason why it was working when I made the tests and not after the PR was opened and merged.