### PR TITLE
Separate build and update image scripts

### DIFF
--- a/batch/build_ecs_image.sh
+++ b/batch/build_ecs_image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd docker || exit
+
+echo "Logging in external ECS where our base image is"
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
+
+echo "Building the image"
+docker build -t tesselo-pixels .
+
+echo "Logging in our private docker repository in AWS"
+aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 595064993071.dkr.ecr.eu-central-1.amazonaws.com
+
+echo "Tagging the newly built image"
+docker tag tesselo-pixels:latest 595064993071.dkr.ecr.eu-central-1.amazonaws.com/tesselo-pixels:latest

--- a/batch/update_ecs_image.sh
+++ b/batch/update_ecs_image.sh
@@ -1,18 +1,6 @@
 #!/bin/sh
 
-cd docker
-
-echo "Logging in external ECS where our base image is"
-aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
-
-echo "Building the image"
-docker build -t tesselo-pixels .
-
-echo "Logging in our private docker repository in AWS"
-aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 595064993071.dkr.ecr.eu-central-1.amazonaws.com
-
-echo "Tagging the newly built image"
-docker tag tesselo-pixels:latest 595064993071.dkr.ecr.eu-central-1.amazonaws.com/tesselo-pixels:latest
+./build_ecs_image.sh
 
 echo "Pushing the image to our ECS repository"
 docker push 595064993071.dkr.ecr.eu-central-1.amazonaws.com/tesselo-pixels:latest


### PR DESCRIPTION
This is useful when debugging the batch image and we made some change in the requirements to test locally before pushing to the ECS repo.