### PR TITLE
fix(retrieve): add gcs fallback for scenes with missing crs data

### DIFF
--- a/pixels/const.py
+++ b/pixels/const.py
@@ -51,7 +51,12 @@ S2_L1C_URL = "s3://sentinel-s2-l1c"
 LS_L2_URL = "s3://usgs-landsat/collection02/level-2/standard"
 BASE_SENTINEL = "gs://gcp-public-data-sentinel-2/tiles"
 BASE_LANDSAT = "gs://gcp-public-data-landsat"
-
+S2_JP2_GOOGLE_FALLBACK_URL_TEMPLATE = (
+    "https://storage.googleapis.com/gcp-public-data-sentinel-2/L2/"
+    "tiles/{utm}/{lat}/{gridsq}/{prod}.SAFE"
+    "/GRANULE/L2A_T{utm}{lat}{gridsq}_A{dtid}_{time}/"
+    "IMG_DATA/R{resolution}m/T{utm}{lat}{gridsq}_{time2}_{band}_{resolution}m.jp2"
+)
 
 # Platform Dates [min,max]
 L1_DATES = ["1972-07-23", "1978-01-07"]

--- a/pixels/retrieve.py
+++ b/pixels/retrieve.py
@@ -12,6 +12,8 @@ from pixels.utils import (
     compute_mask,
     compute_transform,
     is_sentinel_cog_bucket,
+    is_sentinel_jp2_bucket,
+    jp2_to_gcs_bucket,
 )
 
 
@@ -74,6 +76,17 @@ def retrieve(
             logger.warning(f"Retrying retrieve for {source} in the JP2 bucket")
             return retrieve(
                 cog_to_jp2_bucket(source),
+                geojson,
+                scale,
+                discrete,
+                clip,
+                all_touched,
+                bands,
+            )
+        elif is_sentinel_jp2_bucket(source):
+            logger.warning(f"Retrying retrieve for {source} in the GCS bucket")
+            return retrieve(
+                jp2_to_gcs_bucket(source),
                 geojson,
                 scale,
                 discrete,

--- a/tests/data/productInfo.json
+++ b/tests/data/productInfo.json
@@ -1,0 +1,24 @@
+{
+  "name" : "S2B_MSIL2A_20190301T202209_N0211_R042_T02DMG_20190301T220107",
+  "id" : "7f8ed0c0-c314-4827-88af-33ff60768882",
+  "path" : "products/2019/3/1/S2B_MSIL2A_20190301T202209_N0211_R042_T02DMG_20190301T220107",
+  "timestamp" : "2019-03-01T20:22:09.024Z",
+  "datatakeIdentifier" : "GS2B_20190301T202209_010364_N02.11",
+  "sciHubIngestion" : "2019-03-05T11:53:05.318Z",
+  "s3Ingestion" : "2019-03-05T13:38:33.932Z",
+  "tiles" : [ {
+    "path" : "tiles/2/D/MG/2019/3/1/0",
+    "timestamp" : "2019-03-01T20:36:31.812Z",
+    "utmZone" : 2,
+    "latitudeBand" : "D",
+    "gridSquare" : "MG",
+    "datastrip" : {
+      "id" : "S2B_OPER_MSI_L2A_DS_MTI__20190301T220107_S20190301T202210_N02.11",
+      "path" : "products/2019/3/1/S2B_MSIL2A_20190301T202209_N0211_R042_T02DMG_20190301T220107/datastrip/0"
+    }
+  } ],
+  "datastrips" : [ {
+    "id" : "S2B_OPER_MSI_L2A_DS_MTI__20190301T220107_S20190301T202210_N02.11",
+    "path" : "products/2019/3/1/S2B_MSIL2A_20190301T202209_N0211_R042_T02DMG_20190301T220107/datastrip/0"
+  } ]
+}

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -677,3 +677,7 @@ sample_geojson = {
         },
     ],
 }
+
+product_info_mock = MagicMock(
+    return_value={"Body": open("tests/data/productInfo.json")}
+)


### PR DESCRIPTION
Unfortunately the GCS link requires additional metadata that is not in the original link. So we have to download the `productInfo.json` file to construct the fallback link. This should be a rare case though.