### PR TITLE
Add batch job id and attempt to the logs

### DIFF
--- a/pixels/utils.py
+++ b/pixels/utils.py
@@ -477,6 +477,12 @@ class BoundLogger:
 
         self.context = context or {}
 
+        if os.environ.get("AWS_BATCH_JOB_ID"):
+            self.context["AWS_BATCH_JOB_ID"] = os.environ.get("AWS_BATCH_JOB_ID")
+            self.context["AWS_BATCH_JOB_ATTEMPT"] = os.environ.get(
+                "AWS_BATCH_JOB_ATTEMPT"
+            )
+
     def _log_context(self):
         context = {"log_id": self.log_id}
 


### PR DESCRIPTION
Coming from here: https://tesselo.slack.com/archives/C01SF1KHC77/p1653638289682279

This will make linking the job logs in datadog from pxapi easy