### PR TITLE
fix(training): reactivate default keras logging until custom works

### DIFF
--- a/pixels/generator/stac_training.py
+++ b/pixels/generator/stac_training.py
@@ -381,7 +381,7 @@ def train_model_function(
                 ),
                 LogProgress(),
             ],
-            verbose=0,
+            verbose=2,
         )
     else:
         # Fit model with generator directly.
@@ -395,7 +395,7 @@ def train_model_function(
                 ),
                 LogProgress(),
             ],
-            verbose=0,
+            verbose=2,
         )
     # Write history.
     if model_config_uri.startswith("s3"):


### PR DESCRIPTION
I propose to temporarily reactivate the default logs. The evaluation data is critical for modeling, so this will imediately unblock analysis and still allow for testing the better logging.