### PR TITLE
Add train and test end keras logs

### DIFF
--- a/pixels/generator/stac_training.py
+++ b/pixels/generator/stac_training.py
@@ -224,17 +224,24 @@ class LogProgress(tf.keras.callbacks.Callback):
     Custom Callback function to log training progress.
     """
 
-    def _log_status(self, state, epoch, logs):
-        logs = logs or {}
-        logger.info(
-            state, current_epoch=epoch + 1, all_epochs=self.params["epochs"], **logs
-        )
+    def _log_status(self, state, logs=None, epoch=None):
+        extra = logs or {}
+        if epoch is not None:
+            extra["current_epoch"] = epoch + 1
+            extra["all_epochs"] = self.params["epochs"]
+        logger.info(state, **extra)
 
     def on_epoch_begin(self, epoch, logs=None):
-        self._log_status("Epoch begin", epoch, logs)
+        self._log_status("Epoch begin", logs, epoch)
 
     def on_epoch_end(self, epoch, logs=None):
-        self._log_status("Epoch end", epoch, logs)
+        self._log_status("Epoch end", logs, epoch)
+
+    def on_train_end(self, logs=None):
+        self._log_status("Training end", logs)
+
+    def on_test_end(self, logs=None):
+        self._log_status("Evaluation end", logs)
 
 
 @log_function


### PR DESCRIPTION
Our custom logging callback was printing things only at the beginning and end of the training epochs, but not at the end of the complete training or when evaluating the model. Now it will.