### PR TITLE
feat(search): use only stac db for search

### DIFF
--- a/pixels/config/db_config.py
+++ b/pixels/config/db_config.py
@@ -3,20 +3,6 @@ import os
 from sqlalchemy import create_engine
 
 
-def create_db_engine_pixels():
-    """
-    Create database engine from environment variables to Pixels DB.
-    """
-    pg_user = os.environ.get("DB_USER_PIXELS", "postgres")
-    pg_pass = os.environ.get("DB_PASS_PIXELS", "")
-    pg_host = os.environ.get("DB_HOST_PIXELS", "localhost")
-    pg_port = os.environ.get("DB_PORT_PIXELS", "5432")
-    pg_dbname = os.environ.get("DB_NAME_PIXELS", "pixels")
-    db_url = f"postgresql+pg8000://{pg_user}:{pg_pass}@{pg_host}:{pg_port}/{pg_dbname}"
-
-    return create_engine(db_url, client_encoding="utf8")
-
-
 def create_db_engine_pxsearch():
     """
     Create database engine from environment variables to Pxsearch Db.

--- a/pixels/const.py
+++ b/pixels/const.py
@@ -120,7 +120,6 @@ BAND_THERMAL1 = "tirsi"
 BAND_THERMAL2 = "tirsii"
 
 # Create bands list for each platform
-L4_5_SENSOR_ID = "TM"
 S2_BANDS = [
     "B01",
     "B02",

--- a/pixels/mosaic.py
+++ b/pixels/mosaic.py
@@ -63,7 +63,6 @@ def latest_pixel(
     pool_bands=False,
     maxcloud=None,
     level=None,
-    sensor=None,
     start_date=None,
 ):
     """
@@ -109,8 +108,6 @@ def latest_pixel(
         The level of image processing for Sentinel-2 satellite. It can be 'L1C'(Level-1C)
         or 'L2A'(Level-2A) that provides Bottom Of Atmosphere (BOA) reflectance images
         derived from associated Level-1C products. Ignored if platforms is not Sentinel 2.
-    sensor: str, optional
-        Sensor mode for Landsat 1-5. Must be one of be TM or MSS.
     start_date : str, datetime, optional
         A parseable date or datetime string. Represents the starting date of the
         input imagery. Only images after that date will be used for creating
@@ -149,7 +146,7 @@ def latest_pixel(
             platforms=platforms,
             maxcloud=maxcloud,
             level=level,
-            sensor=sensor,
+            bands=bands,
         )
         # Return early if no items could be found.
         if not items:
@@ -168,7 +165,7 @@ def latest_pixel(
     mask = None
     # Get data for each item.
     for item in items:
-        logger.debug(item["product_id"])
+        logger.debug(f"Processing item {item['id']}")
         # Track first end date (the highest priority image in stack).
         if first_end_date is None:
             first_end_date = str(items[0]["sensing_time"].date())
@@ -177,7 +174,7 @@ def latest_pixel(
         for band in bands:
             if band not in item["bands"]:
                 raise PixelsException(
-                    f"Latest pixel requested for a band not present: {band} in {item['base_url']}"
+                    f"Latest pixel requested for a band not present: {band} in {item['id']}"
                 )
             band_list.append(
                 (
@@ -215,9 +212,7 @@ def latest_pixel(
 
         # Continue to next scene if retrieval of bands failed.
         if failed_retrieve:
-            logger.warning(
-                f"Failed retrieval of bands for {item['product_id']}, continuing."
-            )
+            logger.warning(f"Failed retrieval of bands for {item['id']}, continuing.")
             continue
 
         # Continue if this scene was empty.
@@ -278,7 +273,6 @@ def pixel_stack(
     pool_size=5,
     pool_bands=False,
     level=None,
-    sensor=None,
     mode="latest_pixel",
     composite_method="SCL",
 ):
@@ -303,7 +297,7 @@ def pixel_stack(
             platforms=platforms,
             maxcloud=maxcloud,
             level=level,
-            sensor=sensor,
+            bands=bands,
         )
 
         if not response:
@@ -543,6 +537,7 @@ def composite(
         maxcloud=maxcloud,
         level=level,
         sort=sort,
+        bands=bands,
     )
 
     if not items:

--- a/pixels/search.py
+++ b/pixels/search.py
@@ -1,31 +1,18 @@
-from dateutil.parser import parse
-
-from pixels.config.db_config import create_db_engine_pixels, create_db_engine_pxsearch
-from pixels.const import (
-    BASE_LANDSAT,
-    GOOGLE_URL,
-    L1_L2_L3_BANDS,
-    L4_L5_BANDS,
-    L4_L5_BANDS_MSS,
-    L7_BANDS,
-    L8_BANDS,
-    LANDSAT_4,
-    LANDSAT_5,
-    LANDSAT_7,
-    LANDSAT_8,
-    LS_BANDS_NAMES,
-    LS_LOOKUP,
-    S2_BANDS,
-    S2_BANDS_L2A,
-    S2_L1C_URL,
-    S2_L2A_URL,
-    SENTINEL_2,
-)
+from pixels.config.db_config import create_db_engine_pxsearch
 from pixels.log import logger
 from pixels.utils import compute_wgs83_bbox
 
-pixels_db_engine = create_db_engine_pixels()
-pxsearch_db_engine = create_db_engine_pxsearch()
+engine = create_db_engine_pxsearch()
+
+
+def prep_in_array_query(data):
+    return ",".join("'" + dat + "'" for dat in data)
+
+
+def execute_query(query):
+    connection = engine.connect(close_with_result=True)
+    db_result = connection.execute(query)
+    return [dict(row) for row in db_result]
 
 
 def search_data(
@@ -34,438 +21,77 @@ def search_data(
     end=None,
     platforms=None,
     maxcloud=None,
-    scene=None,
-    sensor=None,
     level=None,
     limit=10,
     sort="sensing_time",
+    bands=None,
 ):
-    """
-    Search for satellite images in an area of interest, for a given time interval,
-    according to specificities such as the percentage of cloud cover, satellite or
-    level of image processing.
 
-    Return links to download bands for each scene resulting in the search.
-
-    Parameters
-    ----------
-        geojson : dict
-            The area over which the data will be selected. The geometry extent will be used
-            as bounding box to select images that intersect it.
-        start : str, optional
-            The date to start search on pixels.
-        end : str, optional
-            The date to end search on pixels.
-        platforms : str or list, optional
-            The selection of satellites to search for images on pixels. The satellites
-            can be from Landsat collection or Sentinel 2. The str or list must contain
-            the following values: 'SENTINEL_2', 'LANDSAT_1', 'LANDSAT_2', 'LANDSAT_3',
-            'LANDSAT_4', 'LANDSAT_5', 'LANDSAT_7' or'LANDSAT_8'. If ignored, it returns
-            values from different platforms according to the combination of the other
-            parameters.
-        maxcloud : int, optional
-            Maximun accepted cloud coverage in images. If not provided returns records with
-            up to 100% cloud coverage.
-        scene : str, optional
-            The product id to search for a specific scene. Ignored if not provided.
-        sensor: str, optional
-            The imager sensor used in the Landsat 4. It can be 'MSS' or 'TM'.
-        level : str, optional
-            The level of image processing for Sentinel-2 satellite. It can be 'L1C'(Level-1C)
-            or 'L2A'(Level-2A) that provides Bottom Of Atmosphere (BOA) reflectance images
-            derived from associated Level-1C products. Ignored if platforms is not Sentinel 2.
-        limit : int, optional
-            Specifies the number of records to be returned in the search result.
-        sort : str, optional
-            Defines the ordering of the results. By default, sensing time is used, ordering
-            the images from the most recent date to the oldest. Another option to order the
-            results is the cloud cover which are ordered from the least cloudy to the
-            cloudiest. Allowed values are "sensing_time" and "cloud_cover".
-    Returns
-    -------
-        result : list
-            List of dictionaries with characteristics of each scene present in the search
-            result and the respective links to download each band.
-    """
-
-    db_result = execute_query(
-        geojson, start, end, platforms, maxcloud, scene, sensor, level, limit, sort
-    )
-
-    results = [dict(row) for row in db_result]
-    scenes_result = get_bands(results, level=level)
-    # Convert cloud cover into float to allow json serialization of the output.
-    for dat in scenes_result:
-        dat["cloud_cover"] = float(dat["cloud_cover"])
-
-    # Remove assets from final scenes_result
-    if level == "L2":
-        for dat in scenes_result:
-            if "links" in dat:
-                del dat["links"]
-
-    logger.debug(f"Found {len(scenes_result)} in search.")
-
-    return scenes_result
-
-
-def execute_query(
-    geojson, start, end, platforms, maxcloud, scene, sensor, level, limit, sort
-):
-    """
-    Connects to the database, considering the level passed, and then executes the query.
-
-    Parameters
-    ----------
-        geojson : dict
-            The area over which the data will be selected. The geometry extent will be used
-            as bounding box to select images that intersect it.
-        start : str, optional
-            The date to start search on pixels.
-        end : str, optional
-            The date to end search on pixels.
-        platforms : str or list, optional
-            The selection of satellites to search for images on pixels. The satellites
-            can be from Landsat collection or Sentinel 2. The str or list must contain
-            the following values: 'SENTINEL_2', 'LANDSAT_1', 'LANDSAT_2', 'LANDSAT_3',
-            'LANDSAT_4', 'LANDSAT_5', 'LANDSAT_7' or'LANDSAT_8'. If ignored, it returns
-            values from different platforms according to the combination of the other
-            parameters.
-        maxcloud : int, optional
-            Maximum accepted cloud coverage in images. If not provided returns records with
-            up to 100% cloud coverage.
-        scene : str, optional
-            The product id to search for a specific scene. Ignored if not provided.
-        sensor: str, optional
-            The imager sensor used in the Landsat 4. It can be 'MSS' or 'TM'.
-        level : str, optional
-            The level of image processing for Sentinel-2 or Landsat Collection 2.
-            For the first one, it can be 'L1C'(Level-1C) or 'L2A'(Level-2A) that provides
-            Bottom Of Atmosphere (BOA) reflectance images derived from associated Level-1C products.
-            For Landsat the value passed must be 'L2', that includes scene-based global Level-2 surface reflectance and surface temperature science products.
-            Ignored if platforms is not Sentinel 2.
-        limit : int, optional
-            Specifies the number of records to be returned in the search result.
-        sort : str, optional
-            Defines the ordering of the results. By default, sensing time is used, ordering
-            the images from the most recent date to the oldest. Another option to order the
-            results is the cloud cover which are ordered from the least cloudy to the
-            cloudiest. Allowed values are "sensing_time" and "cloud_cover".
-
-    Returns
-    -------
-        query :
-            a sqlalchemy engine cursor to query execution.
-
-    """
-    collection = "landsat-c2l2-sr" if level == "L2" else None
-    query = build_query(
-        start, end, platforms, maxcloud, scene, sensor, level, limit, sort, collection
-    )
-    # Getting bounds.
     xmin, ymin, xmax, ymax = compute_wgs83_bbox(geojson, return_bbox=True)
 
-    # Format and execute query.
-    if level == "L2":
-        formatted_query = query.format(
-            xmin=xmin,
-            xmax=xmax,
-            ymin=ymin,
-            ymax=ymax,
-            schema="data",
-            mgrs_tile="",
-            granule_id="",
-            links=", links",
-        )
-        engine = pxsearch_db_engine
-    else:
-        formatted_query = query.format(
-            xmin=xmin,
-            xmax=xmax,
-            ymin=ymin,
-            ymax=ymax,
-            schema="public",
-            mgrs_tile=" mgrs_tile, ",
-            granule_id=" granule_id, ",
-            links="",
-        )
-        engine = pixels_db_engine
-
-    connection = engine.connect(close_with_result=True)
-    return connection.execute(formatted_query)
-
-
-def build_query(
-    start, end, platforms, maxcloud, scene, sensor, level, limit, sort, collection
-):
+    query = f"""
+    SELECT id, collection_id, datetime, properties, assets FROM data.items
+    WHERE ST_Intersects(ST_MakeEnvelope({xmin}, {ymin},{xmax},{ymax},4326), geometry)
     """
-    Format and add parameters to query template.
 
-    Parameters
-    ----------
-        start : str, optional
-            The date to start search on pixels.
-        end : str, optional
-            The date to end search on pixels.
-        platforms : str or list, optional
-            The selection of satellites to search for images on pixels. The satellites
-            can be from Landsat collection or Sentinel 2. The str or list must contain
-            the following values: 'SENTINEL_2', 'LANDSAT_1', 'LANDSAT_2', 'LANDSAT_3',
-            'LANDSAT_4', 'LANDSAT_5', 'LANDSAT_7' or'LANDSAT_8'. If ignored, it returns
-            values from different platforms according to the combination of the other
-            parameters.
-        maxcloud : int, optional
-            Maximun accepted cloud coverage in images. If not provided returns records with
-            up to 100% cloud coverage.
-        scene : str, optional
-            The product id to search for a specific scene. Ignored if not provided.
-        sensor: str, optional
-            The imager sensor used in the Landsat 4. It can be 'MSS' or 'TM'.
-        level : str, optional
-            The level of image processing for Sentinel-2 or Landsat Collection 2.
-            For the first one, it can be 'L1C'(Level-1C) or 'L2A'(Level-2A) that provides
-            Bottom Of Atmosphere (BOA) reflectance images derived from associated Level-1C products.
-            For Landsat the value passed must be 'L2', that includes scene-based global Level-2
-            surface reflectance and surface temperature science products.
-            Ignored if platforms is not Sentinel 2.
-        limit : int, optional
-            Specifies the number of records to be returned in the search result.
-        sort : str, optional
-            Defines the ordering of the results. By default, sensing time is used, ordering
-            the images from the most recent date to the oldest. Another option to order the
-            results is the cloud cover which are ordered from the least cloudy to the
-            cloudiest. Allowed values are "sensing_time" and "cloud_cover".
-        collection : str
-            Defines collection (1 or 2) and type of product ( Surface reflectance - SR
-            or Surface Temperature - ST).
-
-    Returns
-    -------
-        query : str
-            query template to execute in postgreSQL.
-    """
-    # Ensure platforms follow the list format.
-    if platforms is not None and not isinstance(platforms, (list, tuple)):
-        platforms = [platforms]
-
-    # SQL query template.
-    query = "SELECT spacecraft_id, sensor_id, product_id, {granule_id} sensing_time, {mgrs_tile} cloud_cover, wrs_path, wrs_row, base_url {links} FROM {schema}.imagery WHERE ST_Intersects(ST_MakeEnvelope({xmin}, {ymin},{xmax},{ymax},4326), bbox)"
-
-    # Check inputs.
-    if start is not None:
-        query += " AND sensing_time >= timestamp '{}' ".format(start)
-    if end is not None:
-        query += " AND sensing_time <= timestamp '{}' ".format(end)
-    if platforms is not None:
-        query += " AND spacecraft_id IN ({})".format(
-            (",".join("'" + plat + "'" for plat in platforms))
-        )
-    if maxcloud is not None:
-        query += " AND cloud_cover <= {} ".format(float(maxcloud))
-    if scene is not None:
-        query += " AND product_id = '{}' ".format(scene)
-    if sensor is not None:
-        query += " AND sensor_id = '{}' ".format(sensor)
-    if is_level_valid(level, platforms):
-        query += " AND granule_id LIKE '{}%'".format(level)
-    if collection is not None:
-        query += " AND collection_id = '{}' ".format(collection)
-    if sort is not None:
-        sort_order = "ASC" if sort == "cloud_cover" else "DESC"
-        query += " ORDER BY {} {}".format(sort, sort_order)
-    if limit is not None:
-        query += " LIMIT {};".format(limit)
-
-    return query
-
-
-def get_bands(response, level):
-    """
-    Decides which method use to format bands and generate links to download it.
-
-    Parameters
-    ----------
-        response : list
-            List of dictionaries with scenes presents in the search result.
-    Returns
-    -------
-        result : list
-            List of dictionaries with scenes and bands with the respective links.
-    """
-    result = []
-    for value in response:
-        if "sentinel-2" in value["base_url"]:
-            value["bands"] = format_sentinel_band(value)
-        elif level == "L2":
-            value["bands"] = format_ls_c2_bands(value)
+    collections = []
+    if any(["LANDSAT" in platform for platform in platforms]):
+        collections.append("landsat-c2l2-sr")
+    if any(["SENTINEL_2" == platform for platform in platforms]):
+        if level == "L2A":
+            collections.append("sentinel-s2-l2a-cogs")
         else:
-            value["bands"] = format_ls_c1_band(value)
+            collections.append("sentinel-s2-l1c")
+    if collections:
+        query += f" AND collection_id IN ({prep_in_array_query(collections)})"
 
-        result.append(value)
+    if start is not None:
+        query += f" AND datetime >= timestamp '{start}' "
+    if end is not None:
+        query += f" AND datetime <= timestamp '{end}' "
+    if maxcloud is not None:
+        query += f" AND (properties -> 'eo:cloud_cover')::float < {maxcloud}"
+    if sort == "cloud_cover":
+        query += " ORDER BY properties -> 'eo:cloud_cover' ASC"
+    elif sort:
+        query += " ORDER BY datetime DESC"
+    if limit is not None:
+        query += " LIMIT {}".format(limit)
+
+    query_results = execute_query(query)
+
+    result = []
+    for item in query_results:
+        # Skip unwanted landsat platforms.
+        platform = item["properties"].get("platform")
+        if "sentinel" not in platform and platform not in platforms:
+            continue
+
+        band_hrefs = {}
+        for key, val in item["assets"].items():
+            if key == "SCL":
+                band = "SCL"
+            elif len(val.get("eo:bands", [])) == 1:
+                band = val["eo:bands"][0]["name"]
+            else:
+                logger.debug(f"Skipping band {key}")
+                continue
+
+            if band not in bands:
+                continue
+
+            if "alternate" in val:
+                band_hrefs[band] = val["alternate"]["s3"]["href"]
+            else:
+                band_hrefs[band] = val["href"]
+
+        result.append(
+            {
+                "id": item["id"],
+                "sensing_time": item["datetime"],
+                "bands": band_hrefs,
+                "cloud_cover": item["properties"].get("eo:cloud_cover", None),
+            }
+        )
 
     return result
-
-
-def format_sentinel_band(value):
-    """
-    Format base url and generate links to download sentinel bands.
-
-    Parameters
-    ----------
-        value : dict
-            Dictionary with characteristics of a scene (product id, sensing time, etc.).
-
-    Returns
-    -------
-        data : dict
-            Dictionary of each band url.
-    """
-    mgr = value["mgrs_tile"]
-    utm_zone = mgr[:2]
-    latitude_code = mgr[2:3]
-    square_grid = mgr[3:5]
-    date = parse(str(value["sensing_time"]))
-    product_id = value["product_id"]
-    sensing_time = str(date.date()).replace("-", "")
-    sequence = 0
-    level = value["granule_id"][:3]
-    data = {}
-
-    if level == "L2A":
-        for band in S2_BANDS_L2A:
-            band_template_url = "{base_url}/{utm}/{latitude}/{grid}/{year}/{month}/{product_id}_{mgr}_{sensing_time}_{sequence}_{level}/{band}.tif"
-            data[band] = band_template_url.format(
-                base_url=S2_L2A_URL,
-                utm=utm_zone,
-                latitude=latitude_code,
-                grid=square_grid,
-                year=date.year,
-                month=date.month,
-                product_id=product_id[:3],
-                mgr=mgr,
-                sensing_time=sensing_time,
-                sequence=sequence,
-                level=level,
-                band=band,
-            )
-    else:
-        for band in S2_BANDS:
-            band_template_url = "{base_url}/tiles/{utm}/{latitude}/{grid}/{year}/{month}/{day}/{sequence}/{band}.jp2"
-            data[band] = band_template_url.format(
-                base_url=S2_L1C_URL,
-                utm=utm_zone,
-                latitude=latitude_code,
-                grid=square_grid,
-                year=date.year,
-                month=date.month,
-                day=date.day,
-                sequence=sequence,
-                band=band,
-            )
-
-    return data
-
-
-def format_ls_c1_band(value):
-    """
-    Format base url and generate links to download landsat bands.
-
-    Parameters
-    ----------
-        value : dict
-            Dictionary with characteristics of a scene (product id, sensing time, etc.).
-
-    Returns
-    -------
-        data : dict
-            Dictionary of each band url.
-    """
-    plat = value["spacecraft_id"]
-    product_id = value["product_id"]
-    sensor = value["sensor_id"]
-    data = {}
-    if plat == LANDSAT_8:
-        for band in L8_BANDS:
-            base_url = "{}".format(value["base_url"]).replace(BASE_LANDSAT, GOOGLE_URL)
-            ls_band_template = "{base_url}/{product_id}_{band}.TIF"
-
-            data[band] = ls_band_template.format(
-                base_url=base_url, product_id=product_id, band=band
-            )
-    elif plat == LANDSAT_7:
-        for band in L7_BANDS:
-            base_url = "{}".format(value["base_url"]).replace(BASE_LANDSAT, GOOGLE_URL)
-            ls_band_template = "{base_url}/{product_id}_{band}.TIF"
-
-            data[band] = ls_band_template.format(
-                base_url=base_url, product_id=product_id, band=band
-            )
-
-    elif plat == LANDSAT_4 or plat == LANDSAT_5 and sensor == "TM":
-        for band in L4_L5_BANDS:
-            base_url = "{}".format(value["base_url"]).replace(BASE_LANDSAT, GOOGLE_URL)
-            ls_band_template = "{base_url}/{product_id}_{band}.TIF"
-
-            data[band] = ls_band_template.format(
-                base_url=base_url, product_id=product_id, band=band
-            )
-    elif plat == LANDSAT_4 or plat == LANDSAT_5 and sensor == "MSS":
-        for band in L4_L5_BANDS_MSS:
-            base_url = "{}".format(value["base_url"]).replace(BASE_LANDSAT, GOOGLE_URL)
-            ls_band_template = "{base_url}/{product_id}_{band}.TIF"
-
-            data[band] = ls_band_template.format(
-                base_url=base_url, product_id=product_id, band=band
-            )
-    else:
-        for band in L1_L2_L3_BANDS:
-            base_url = "{}".format(value["base_url"]).replace(BASE_LANDSAT, GOOGLE_URL)
-            ls_band_template = "{base_url}/{product_id}_{band}.TIF"
-
-            data[band] = ls_band_template.format(
-                base_url=base_url, product_id=product_id, band=band
-            )
-    return data
-
-
-def is_level_valid(level, platforms):
-    """
-    Checks whether the use of the Level parameter is valid.
-
-    Parameters
-    ----------
-        level : str
-            Image processing level for Sentinel 2.
-        platforms : list or tuple
-            The selection of satellites to search for images on pixels.
-    Returns
-    -------
-        True if the level is not empty, the platform is a unique value list and contains
-        Sentinel 2.
-    """
-    return level is not None and len(platforms) == 1 and platforms[0] == SENTINEL_2
-
-
-def format_ls_c2_bands(value):
-    """
-        Get  links to download landsat collection 02 bands from assets data.
-
-    Parameters
-    ----------
-        value : dict
-            Dictionary with characteristics of a scene (product id, sensing time, assets, etc.).
-
-    Returns
-    -------
-        bands_links : dict
-            Dictionary of each band url.
-    """
-
-    bands_links = {}
-
-    links = value["links"]
-    for band_name, band_data in links.items():
-        if band_name in LS_BANDS_NAMES:
-            bands_links[LS_LOOKUP[band_name]] = band_data["alternate"]["s3"]["href"]
-
-    return bands_links

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -1,457 +1,1147 @@
 import datetime
 from unittest.mock import MagicMock
 
-# Mock data for sentinel 2.
 sentinel_2_data_mock = MagicMock(
     return_value=[
         {
-            "spacecraft_id": "SENTINEL_2",
-            "sensor_id": None,
-            "product_id": "S2A_MSIL2A_20201211T134211_N0214_R124_T22MGD_20201211T160214",
-            "granule_id": "L2A_T22MGD_A028578_20201211T134207",
-            "sensing_time": datetime.datetime(2020, 12, 11, 13, 42, 43, 997000),
-            "mgrs_tile": "22MGD",
-            "cloud_cover": 11.373496,
-            "base_url": "gs://gcp-public-data-sentinel-2/L2/tiles/22/M/GD/S2A_MSIL2A_20201211T134211_N0214_R124_T22MGD_20201211T160214.SAFE",
-        }
+            "id": "S2A_29TNG_20170128_0_L2A",
+            "collection_id": "sentinel-s2-l2a-cogs",
+            "datetime": datetime.datetime(
+                2017, 1, 28, 11, 33, 22, tzinfo=datetime.timezone.utc
+            ),
+            "properties": {
+                "gsd": 10,
+                "created": "2020-09-18T06:14:23.388Z",
+                "updated": "2020-09-18T06:14:23.388Z",
+                "datetime": "2017-01-28T11:33:22Z",
+                "platform": "sentinel-2a",
+                "proj:epsg": 32629,
+                "instruments": ["msi"],
+                "constellation": "sentinel-2",
+                "eo:cloud_cover": 81.59,
+                "view:off_nadir": 0,
+                "sentinel:sequence": "0",
+                "sentinel:utm_zone": 29,
+                "sentinel:product_id": "S2A_MSIL2A_20170128T113321_N0001_R080_T29TNG_20190506T060629",
+                "sentinel:grid_square": "NG",
+                "sentinel:data_coverage": 88.44,
+                "sentinel:latitude_band": "T",
+                "sentinel:valid_cloud_cover": True,
+            },
+            "assets": {
+                "AOT": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/AOT.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Aerosol Optical Thickness (AOT)",
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B01": {
+                    "gsd": 60,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B01.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 1 (coastal)",
+                    "eo:bands": [
+                        {
+                            "name": "B01",
+                            "common_name": "coastal",
+                            "center_wavelength": 0.4439,
+                            "full_width_half_max": 0.027,
+                        }
+                    ],
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B02": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B02.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 2 (blue)",
+                    "eo:bands": [
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B03": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B03.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 3 (green)",
+                    "eo:bands": [
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B04": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B04.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 4 (red)",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B05": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B05.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 5",
+                    "eo:bands": [
+                        {
+                            "name": "B05",
+                            "center_wavelength": 0.7039,
+                            "full_width_half_max": 0.019,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B06": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B06.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 6",
+                    "eo:bands": [
+                        {
+                            "name": "B06",
+                            "center_wavelength": 0.7402,
+                            "full_width_half_max": 0.018,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B07": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B07.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 7",
+                    "eo:bands": [
+                        {
+                            "name": "B07",
+                            "center_wavelength": 0.7825,
+                            "full_width_half_max": 0.028,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B08": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B08.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 8 (nir)",
+                    "eo:bands": [
+                        {
+                            "name": "B08",
+                            "common_name": "nir",
+                            "center_wavelength": 0.8351,
+                            "full_width_half_max": 0.145,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B09": {
+                    "gsd": 60,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B09.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 9",
+                    "eo:bands": [
+                        {
+                            "name": "B09",
+                            "center_wavelength": 0.945,
+                            "full_width_half_max": 0.026,
+                        }
+                    ],
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B11": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B11.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 11 (swir16)",
+                    "eo:bands": [
+                        {
+                            "name": "B11",
+                            "common_name": "swir16",
+                            "center_wavelength": 1.6137,
+                            "full_width_half_max": 0.143,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B12": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B12.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 12 (swir22)",
+                    "eo:bands": [
+                        {
+                            "name": "B12",
+                            "common_name": "swir22",
+                            "center_wavelength": 2.22024,
+                            "full_width_half_max": 0.242,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B8A": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B8A.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 8A",
+                    "eo:bands": [
+                        {
+                            "name": "B8A",
+                            "center_wavelength": 0.8648,
+                            "full_width_half_max": 0.033,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "SCL": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/SCL.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Scene Classification Map (SCL)",
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "WVP": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/WVP.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Water Vapour (WVP)",
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "info": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/29/T/NG/2017/1/28/0/tileInfo.json",
+                    "type": "application/json",
+                    "roles": ["metadata"],
+                    "title": "Original JSON metadata",
+                },
+                "visual": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/TCI.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["overview"],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        },
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "metadata": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/29/T/NG/2017/1/28/0/metadata.xml",
+                    "type": "application/xml",
+                    "roles": ["metadata"],
+                    "title": "Original XML metadata",
+                },
+                "overview": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/L2A_PVI.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["overview"],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        },
+                    ],
+                    "proj:shape": [343, 343],
+                    "proj:transform": [320, 0, 499980, 0, -320, 4700040, 0, 0, 1],
+                },
+                "thumbnail": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/29/T/NG/2017/1/28/0/preview.jpg",
+                    "type": "image/png",
+                    "roles": ["thumbnail"],
+                    "title": "Thumbnail",
+                },
+            },
+        },
+        {
+            "id": "S2A_29TNG_20170105_0_L2A",
+            "collection_id": "sentinel-s2-l2a-cogs",
+            "datetime": datetime.datetime(
+                2017, 1, 5, 11, 27, 37, tzinfo=datetime.timezone.utc
+            ),
+            "properties": {
+                "gsd": 10,
+                "created": "2020-09-01T15:32:53.423Z",
+                "updated": "2020-09-01T15:32:53.423Z",
+                "datetime": "2017-01-05T11:27:37Z",
+                "platform": "sentinel-2a",
+                "proj:epsg": 32629,
+                "instruments": ["msi"],
+                "constellation": "sentinel-2",
+                "eo:cloud_cover": 15.41,
+                "view:off_nadir": 0,
+                "sentinel:sequence": "0",
+                "sentinel:utm_zone": 29,
+                "sentinel:product_id": "S2A_MSIL2A_20170105T112442_N0001_R037_T29TNG_20190506T074729",
+                "sentinel:grid_square": "NG",
+                "sentinel:data_coverage": 96.2,
+                "sentinel:latitude_band": "T",
+                "sentinel:valid_cloud_cover": True,
+            },
+            "assets": {
+                "AOT": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/AOT.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Aerosol Optical Thickness (AOT)",
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B01": {
+                    "gsd": 60,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B01.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 1 (coastal)",
+                    "eo:bands": [
+                        {
+                            "name": "B01",
+                            "common_name": "coastal",
+                            "center_wavelength": 0.4439,
+                            "full_width_half_max": 0.027,
+                        }
+                    ],
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B02": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B02.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 2 (blue)",
+                    "eo:bands": [
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B03": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B03.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 3 (green)",
+                    "eo:bands": [
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B04": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B04.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 4 (red)",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B05": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B05.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 5",
+                    "eo:bands": [
+                        {
+                            "name": "B05",
+                            "center_wavelength": 0.7039,
+                            "full_width_half_max": 0.019,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B06": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B06.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 6",
+                    "eo:bands": [
+                        {
+                            "name": "B06",
+                            "center_wavelength": 0.7402,
+                            "full_width_half_max": 0.018,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B07": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B07.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 7",
+                    "eo:bands": [
+                        {
+                            "name": "B07",
+                            "center_wavelength": 0.7825,
+                            "full_width_half_max": 0.028,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B08": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B08.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 8 (nir)",
+                    "eo:bands": [
+                        {
+                            "name": "B08",
+                            "common_name": "nir",
+                            "center_wavelength": 0.8351,
+                            "full_width_half_max": 0.145,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B09": {
+                    "gsd": 60,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B09.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 9",
+                    "eo:bands": [
+                        {
+                            "name": "B09",
+                            "center_wavelength": 0.945,
+                            "full_width_half_max": 0.026,
+                        }
+                    ],
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B11": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B11.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 11 (swir16)",
+                    "eo:bands": [
+                        {
+                            "name": "B11",
+                            "common_name": "swir16",
+                            "center_wavelength": 1.6137,
+                            "full_width_half_max": 0.143,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B12": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B12.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 12 (swir22)",
+                    "eo:bands": [
+                        {
+                            "name": "B12",
+                            "common_name": "swir22",
+                            "center_wavelength": 2.22024,
+                            "full_width_half_max": 0.242,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B8A": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/B8A.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 8A",
+                    "eo:bands": [
+                        {
+                            "name": "B8A",
+                            "center_wavelength": 0.8648,
+                            "full_width_half_max": 0.033,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "SCL": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/SCL.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Scene Classification Map (SCL)",
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "WVP": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/WVP.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Water Vapour (WVP)",
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "info": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/29/T/NG/2017/1/5/0/tileInfo.json",
+                    "type": "application/json",
+                    "roles": ["metadata"],
+                    "title": "Original JSON metadata",
+                },
+                "visual": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/TCI.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["overview"],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        },
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "metadata": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/29/T/NG/2017/1/5/0/metadata.xml",
+                    "type": "application/xml",
+                    "roles": ["metadata"],
+                    "title": "Original XML metadata",
+                },
+                "overview": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170105_0_L2A/L2A_PVI.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["overview"],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        },
+                    ],
+                    "proj:shape": [343, 343],
+                    "proj:transform": [320, 0, 499980, 0, -320, 4700040, 0, 0, 1],
+                },
+                "thumbnail": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/29/T/NG/2017/1/5/0/preview.jpg",
+                    "type": "image/png",
+                    "roles": ["thumbnail"],
+                    "title": "Thumbnail",
+                },
+            },
+        },
+        {
+            "id": "S2A_29TNG_20170125_0_L2A",
+            "collection_id": "sentinel-s2-l2a-cogs",
+            "datetime": datetime.datetime(
+                2017, 1, 25, 11, 23, 33, tzinfo=datetime.timezone.utc
+            ),
+            "properties": {
+                "gsd": 10,
+                "created": "2020-09-27T22:34:59.897Z",
+                "updated": "2020-09-27T22:34:59.897Z",
+                "datetime": "2017-01-25T11:23:33Z",
+                "platform": "sentinel-2a",
+                "proj:epsg": 32629,
+                "instruments": ["msi"],
+                "constellation": "sentinel-2",
+                "data_coverage": 95.92,
+                "eo:cloud_cover": 2.28,
+                "view:off_nadir": 0,
+                "sentinel:sequence": "0",
+                "sentinel:utm_zone": 29,
+                "sentinel:product_id": "S2A_MSIL2A_20170125T112331_N0001_R037_T29TNG_20190506T120522",
+                "sentinel:grid_square": "NG",
+                "sentinel:data_coverage": 95.92,
+                "sentinel:latitude_band": "T",
+                "sentinel:valid_cloud_cover": True,
+            },
+            "assets": {
+                "AOT": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/AOT.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Aerosol Optical Thickness (AOT)",
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B01": {
+                    "gsd": 60,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B01.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 1 (coastal)",
+                    "eo:bands": [
+                        {
+                            "name": "B01",
+                            "common_name": "coastal",
+                            "center_wavelength": 0.4439,
+                            "full_width_half_max": 0.027,
+                        }
+                    ],
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B02": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B02.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 2 (blue)",
+                    "eo:bands": [
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B03": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B03.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 3 (green)",
+                    "eo:bands": [
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B04": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B04.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 4 (red)",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B05": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B05.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 5",
+                    "eo:bands": [
+                        {
+                            "name": "B05",
+                            "center_wavelength": 0.7039,
+                            "full_width_half_max": 0.019,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B06": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B06.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 6",
+                    "eo:bands": [
+                        {
+                            "name": "B06",
+                            "center_wavelength": 0.7402,
+                            "full_width_half_max": 0.018,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B07": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B07.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 7",
+                    "eo:bands": [
+                        {
+                            "name": "B07",
+                            "center_wavelength": 0.7825,
+                            "full_width_half_max": 0.028,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B08": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B08.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 8 (nir)",
+                    "eo:bands": [
+                        {
+                            "name": "B08",
+                            "common_name": "nir",
+                            "center_wavelength": 0.8351,
+                            "full_width_half_max": 0.145,
+                        }
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "B09": {
+                    "gsd": 60,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B09.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 9",
+                    "eo:bands": [
+                        {
+                            "name": "B09",
+                            "center_wavelength": 0.945,
+                            "full_width_half_max": 0.026,
+                        }
+                    ],
+                    "proj:shape": [1830, 1830],
+                    "proj:transform": [60, 0, 499980, 0, -60, 4700040, 0, 0, 1],
+                },
+                "B11": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B11.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 11 (swir16)",
+                    "eo:bands": [
+                        {
+                            "name": "B11",
+                            "common_name": "swir16",
+                            "center_wavelength": 1.6137,
+                            "full_width_half_max": 0.143,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B12": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B12.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 12 (swir22)",
+                    "eo:bands": [
+                        {
+                            "name": "B12",
+                            "common_name": "swir22",
+                            "center_wavelength": 2.22024,
+                            "full_width_half_max": 0.242,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "B8A": {
+                    "gsd": 20,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/B8A.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Band 8A",
+                    "eo:bands": [
+                        {
+                            "name": "B8A",
+                            "center_wavelength": 0.8648,
+                            "full_width_half_max": 0.033,
+                        }
+                    ],
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "SCL": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/SCL.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Scene Classification Map (SCL)",
+                    "proj:shape": [5490, 5490],
+                    "proj:transform": [20, 0, 499980, 0, -20, 4700040, 0, 0, 1],
+                },
+                "WVP": {
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/WVP.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["data"],
+                    "title": "Water Vapour (WVP)",
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "info": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/29/T/NG/2017/1/25/0/tileInfo.json",
+                    "type": "application/json",
+                    "roles": ["metadata"],
+                    "title": "Original JSON metadata",
+                },
+                "visual": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/TCI.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["overview"],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        },
+                    ],
+                    "proj:shape": [10980, 10980],
+                    "proj:transform": [10, 0, 499980, 0, -10, 4700040, 0, 0, 1],
+                },
+                "metadata": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/29/T/NG/2017/1/25/0/metadata.xml",
+                    "type": "application/xml",
+                    "roles": ["metadata"],
+                    "title": "Original XML metadata",
+                },
+                "overview": {
+                    "gsd": 10,
+                    "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170125_0_L2A/L2A_PVI.tif",
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": ["overview"],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "center_wavelength": 0.6645,
+                            "full_width_half_max": 0.038,
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045,
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "center_wavelength": 0.4966,
+                            "full_width_half_max": 0.098,
+                        },
+                    ],
+                    "proj:shape": [343, 343],
+                    "proj:transform": [320, 0, 499980, 0, -320, 4700040, 0, 0, 1],
+                },
+                "thumbnail": {
+                    "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/29/T/NG/2017/1/25/0/preview.jpg",
+                    "type": "image/png",
+                    "roles": ["thumbnail"],
+                    "title": "Thumbnail",
+                },
+            },
+        },
     ]
 )
 
-s2_expected_scene = {
-    "spacecraft_id": "SENTINEL_2",
-    "sensor_id": None,
-    "product_id": "S2A_MSIL2A_20201211T134211_N0214_R124_T22MGD_20201211T160214",
-    "granule_id": "L2A_T22MGD_A028578_20201211T134207",
-    "sensing_time": datetime.datetime(2020, 12, 11, 13, 42, 43, 997000),
-    "mgrs_tile": "22MGD",
-    "cloud_cover": 11.373496,
-    "base_url": "gs://gcp-public-data-sentinel-2/L2/tiles/22/M/GD/S2A_MSIL2A_20201211T134211_N0214_R124_T22MGD_20201211T160214.SAFE",
-    "bands": {
-        "B01": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B01.tif",
-        "B02": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B02.tif",
-        "B03": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B03.tif",
-        "B04": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B04.tif",
-        "B05": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B05.tif",
-        "B06": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B06.tif",
-        "B07": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B07.tif",
-        "B08": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B08.tif",
-        "B8A": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B8A.tif",
-        "B09": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B09.tif",
-        "B11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B11.tif",
-        "B12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/B12.tif",
-        "SCL": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/M/GD/2020/12/S2A_22MGD_20201211_0_L2A/SCL.tif",
-    },
-}
-# Empty rsult.
-empty_data_mock = MagicMock(return_value=[])
-
-# Mock data for landsat 1.
-l1_data_mock = MagicMock(
+landsat_data_mock = MagicMock(
     return_value=[
         {
-            "spacecraft_id": "LANDSAT_1",
-            "sensor_id": "MSS",
-            "product_id": "LM01_L1TP_240061_19730313_20180427_01_T2",
-            "granule_id": None,
-            "sensing_time": datetime.datetime(1973, 3, 13, 12, 57, 5, 41000),
-            "mgrs_tile": None,
-            "cloud_cover": 26.0,
-            "wrs_path": 240,
-            "wrs_row": 61,
-            "base_url": "gs://gcp-public-data-landsat/LM01/01/240/061/LM01_L1TP_240061_19730313_20180427_01_T2",
-        }
-    ]
-)
-
-l1_expected_scene = {
-    "spacecraft_id": "LANDSAT_1",
-    "sensor_id": "MSS",
-    "product_id": "LM01_L1TP_240061_19730313_20180427_01_T2",
-    "granule_id": None,
-    "sensing_time": datetime.datetime(1973, 3, 13, 12, 57, 5, 41000),
-    "mgrs_tile": None,
-    "cloud_cover": 26.0,
-    "wrs_path": 240,
-    "wrs_row": 61,
-    "base_url": "gs://gcp-public-data-landsat/LM01/01/240/061/LM01_L1TP_240061_19730313_20180427_01_T2",
-    "bands": {
-        "B4": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM01/01/240/061/LM01_L1TP_240061_19730313_20180427_01_T2/LM01_L1TP_240061_19730313_20180427_01_T2_B4.TIF",
-        "B5": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM01/01/240/061/LM01_L1TP_240061_19730313_20180427_01_T2/LM01_L1TP_240061_19730313_20180427_01_T2_B5.TIF",
-        "B6": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM01/01/240/061/LM01_L1TP_240061_19730313_20180427_01_T2/LM01_L1TP_240061_19730313_20180427_01_T2_B6.TIF",
-        "B7": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM01/01/240/061/LM01_L1TP_240061_19730313_20180427_01_T2/LM01_L1TP_240061_19730313_20180427_01_T2_B7.TIF",
-    },
-}
-
-# Mock data for landsat 2.
-l2_data_mock = MagicMock(
-    return_value=[
-        {
-            "spacecraft_id": "LANDSAT_2",
-            "sensor_id": "MSS",
-            "product_id": "LM02_L1TP_240061_19781016_20180421_01_T2",
-            "granule_id": None,
-            "sensing_time": datetime.datetime(1978, 10, 16, 12, 28, 9, 899000),
-            "mgrs_tile": None,
-            "cloud_cover": 26.0,
-            "wrs_path": 240,
-            "wrs_row": 61,
-            "base_url": "gs://gcp-public-data-landsat/LM02/01/240/061/LM02_L1TP_240061_19781016_20180421_01_T2",
-        }
-    ]
-)
-
-l2_expected_scene = {
-    "spacecraft_id": "LANDSAT_2",
-    "sensor_id": "MSS",
-    "product_id": "LM02_L1TP_240061_19781016_20180421_01_T2",
-    "granule_id": None,
-    "sensing_time": datetime.datetime(1978, 10, 16, 12, 28, 9, 899000),
-    "mgrs_tile": None,
-    "cloud_cover": 26.0,
-    "wrs_path": 240,
-    "wrs_row": 61,
-    "base_url": "gs://gcp-public-data-landsat/LM02/01/240/061/LM02_L1TP_240061_19781016_20180421_01_T2",
-    "bands": {
-        "B4": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM02/01/240/061/LM02_L1TP_240061_19781016_20180421_01_T2/LM02_L1TP_240061_19781016_20180421_01_T2_B4.TIF",
-        "B5": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM02/01/240/061/LM02_L1TP_240061_19781016_20180421_01_T2/LM02_L1TP_240061_19781016_20180421_01_T2_B5.TIF",
-        "B6": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM02/01/240/061/LM02_L1TP_240061_19781016_20180421_01_T2/LM02_L1TP_240061_19781016_20180421_01_T2_B6.TIF",
-        "B7": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM02/01/240/061/LM02_L1TP_240061_19781016_20180421_01_T2/LM02_L1TP_240061_19781016_20180421_01_T2_B7.TIF",
-    },
-}
-
-# Mock data for landsat 3.
-l3_data_mock = MagicMock(
-    return_value=[
-        {
-            "spacecraft_id": "LANDSAT_3",
-            "sensor_id": "MSS",
-            "product_id": "LM03_L1GS_080061_19780501_20180420_01_T2",
-            "granule_id": None,
-            "sensing_time": datetime.datetime(1978, 5, 1, 21, 21, 14, 72000),
-            "mgrs_tile": None,
-            "cloud_cover": 83.0,
-            "wrs_path": 80,
-            "wrs_row": 61,
-            "base_url": "gs://gcp-public-data-landsat/LM03/01/080/061/LM03_L1GS_080061_19780501_20180420_01_T2",
-        }
-    ]
-)
-
-l3_expected_scene = {
-    "spacecraft_id": "LANDSAT_3",
-    "sensor_id": "MSS",
-    "product_id": "LM03_L1GS_080061_19780501_20180420_01_T2",
-    "granule_id": None,
-    "sensing_time": datetime.datetime(1978, 5, 1, 21, 21, 14, 72000),
-    "mgrs_tile": None,
-    "cloud_cover": 83.0,
-    "wrs_path": 80,
-    "wrs_row": 61,
-    "base_url": "gs://gcp-public-data-landsat/LM03/01/080/061/LM03_L1GS_080061_19780501_20180420_01_T2",
-    "bands": {
-        "B4": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM03/01/080/061/LM03_L1GS_080061_19780501_20180420_01_T2/LM03_L1GS_080061_19780501_20180420_01_T2_B4.TIF",
-        "B5": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM03/01/080/061/LM03_L1GS_080061_19780501_20180420_01_T2/LM03_L1GS_080061_19780501_20180420_01_T2_B5.TIF",
-        "B6": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM03/01/080/061/LM03_L1GS_080061_19780501_20180420_01_T2/LM03_L1GS_080061_19780501_20180420_01_T2_B6.TIF",
-        "B7": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LM03/01/080/061/LM03_L1GS_080061_19780501_20180420_01_T2/LM03_L1GS_080061_19780501_20180420_01_T2_B7.TIF",
-    },
-}
-
-# Mock data for landsat 4.
-l4_data_mock = MagicMock(
-    return_value=[
-        {
-            "spacecraft_id": "LANDSAT_4",
-            "sensor_id": "TM",
-            "product_id": "LT04_L1GS_076061_19930316_20170119_01_T2",
-            "granule_id": None,
-            "sensing_time": datetime.datetime(1993, 3, 16, 21, 28, 24, 379038),
-            "mgrs_tile": None,
-            "cloud_cover": 78.0,
-            "wrs_path": 76,
-            "wrs_row": 61,
-            "base_url": "gs://gcp-public-data-landsat/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2",
-        }
-    ]
-)
-
-l4_expected_scene = {
-    "spacecraft_id": "LANDSAT_4",
-    "sensor_id": "TM",
-    "product_id": "LT04_L1GS_076061_19930316_20170119_01_T2",
-    "granule_id": None,
-    "sensing_time": datetime.datetime(1993, 3, 16, 21, 28, 24, 379038),
-    "mgrs_tile": None,
-    "cloud_cover": 78.0,
-    "wrs_path": 76,
-    "wrs_row": 61,
-    "base_url": "gs://gcp-public-data-landsat/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2",
-    "bands": {
-        "B1": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2/LT04_L1GS_076061_19930316_20170119_01_T2_B1.TIF",
-        "B2": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2/LT04_L1GS_076061_19930316_20170119_01_T2_B2.TIF",
-        "B3": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2/LT04_L1GS_076061_19930316_20170119_01_T2_B3.TIF",
-        "B4": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2/LT04_L1GS_076061_19930316_20170119_01_T2_B4.TIF",
-        "B5": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2/LT04_L1GS_076061_19930316_20170119_01_T2_B5.TIF",
-        "B6": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2/LT04_L1GS_076061_19930316_20170119_01_T2_B6.TIF",
-        "B7": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT04/01/076/061/LT04_L1GS_076061_19930316_20170119_01_T2/LT04_L1GS_076061_19930316_20170119_01_T2_B7.TIF",
-    },
-}
-
-# Mock data for landsat 5.
-l5_data_mock = MagicMock(
-    return_value=[
-        {
-            "spacecraft_id": "LANDSAT_5",
-            "sensor_id": "TM",
-            "product_id": "LT05_L1TP_223061_20111026_20161005_01_T1",
-            "granule_id": None,
-            "sensing_time": datetime.datetime(2011, 10, 26, 13, 11, 1, 160025),
-            "mgrs_tile": None,
-            "cloud_cover": 40.0,
-            "wrs_path": 223,
-            "wrs_row": 61,
-            "base_url": "gs://gcp-public-data-landsat/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1",
-        }
-    ]
-)
-
-l5_expected_scene = {
-    "spacecraft_id": "LANDSAT_5",
-    "sensor_id": "TM",
-    "product_id": "LT05_L1TP_223061_20111026_20161005_01_T1",
-    "granule_id": None,
-    "sensing_time": datetime.datetime(2011, 10, 26, 13, 11, 1, 160025),
-    "mgrs_tile": None,
-    "cloud_cover": 40.0,
-    "wrs_path": 223,
-    "wrs_row": 61,
-    "base_url": "gs://gcp-public-data-landsat/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1",
-    "bands": {
-        "B1": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1/LT05_L1TP_223061_20111026_20161005_01_T1_B1.TIF",
-        "B2": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1/LT05_L1TP_223061_20111026_20161005_01_T1_B2.TIF",
-        "B3": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1/LT05_L1TP_223061_20111026_20161005_01_T1_B3.TIF",
-        "B4": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1/LT05_L1TP_223061_20111026_20161005_01_T1_B4.TIF",
-        "B5": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1/LT05_L1TP_223061_20111026_20161005_01_T1_B5.TIF",
-        "B6": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1/LT05_L1TP_223061_20111026_20161005_01_T1_B6.TIF",
-        "B7": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LT05/01/223/061/LT05_L1TP_223061_20111026_20161005_01_T1/LT05_L1TP_223061_20111026_20161005_01_T1_B7.TIF",
-    },
-}
-
-# Mock data for landsat 7.
-l7_data_mock = MagicMock(
-    return_value=[
-        {
-            "spacecraft_id": "LANDSAT_7",
-            "sensor_id": "ETM",
-            "product_id": "LE07_L1GT_223061_20200128_20200223_01_T2",
-            "granule_id": None,
-            "sensing_time": datetime.datetime(2020, 1, 28, 13, 2, 37, 153212),
-            "mgrs_tile": None,
-            "cloud_cover": 59.0,
-            "base_url": "gs://gcp-public-data-landsat/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2",
-        }
-    ]
-)
-
-l7_expected_scene = {
-    "spacecraft_id": "LANDSAT_7",
-    "sensor_id": "ETM",
-    "product_id": "LE07_L1GT_223061_20200128_20200223_01_T2",
-    "granule_id": None,
-    "sensing_time": datetime.datetime(2020, 1, 28, 13, 2, 37, 153212),
-    "mgrs_tile": None,
-    "cloud_cover": 59.0,
-    "base_url": "gs://gcp-public-data-landsat/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2",
-    "bands": {
-        "B1": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B1.TIF",
-        "B2": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B2.TIF",
-        "B3": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B3.TIF",
-        "B4": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B4.TIF",
-        "B5": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B5.TIF",
-        "B6": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B6.TIF",
-        "B7": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B7.TIF",
-        "B8": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LE07/01/223/061/LE07_L1GT_223061_20200128_20200223_01_T2/LE07_L1GT_223061_20200128_20200223_01_T2_B8.TIF",
-    },
-}
-
-# Mock data for landsat 8.
-l8_data_mock = MagicMock(
-    return_value=[
-        {
-            "spacecraft_id": "LANDSAT_8",
-            "sensor_id": "OLI_TIRS",
-            "product_id": "LC08_L1TP_224061_20210129_20210306_01_T2",
-            "granule_id": None,
-            "sensing_time": datetime.datetime(2021, 1, 29, 13, 29, 24, 756888),
-            "mgrs_tile": None,
-            "cloud_cover": 59.59,
-            "wrs_path": 224,
-            "wrs_row": 61,
-            "base_url": "gs://gcp-public-data-landsat/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2",
-        }
-    ]
-)
-
-l8_expected_scene = {
-    "spacecraft_id": "LANDSAT_8",
-    "sensor_id": "OLI_TIRS",
-    "product_id": "LC08_L1TP_224061_20210129_20210306_01_T2",
-    "granule_id": None,
-    "sensing_time": datetime.datetime(2021, 1, 29, 13, 29, 24, 756888),
-    "mgrs_tile": None,
-    "cloud_cover": 59.59,
-    "wrs_path": 224,
-    "wrs_row": 61,
-    "base_url": "gs://gcp-public-data-landsat/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2",
-    "bands": {
-        "B1": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B1.TIF",
-        "B2": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B2.TIF",
-        "B3": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B3.TIF",
-        "B4": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B4.TIF",
-        "B5": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B5.TIF",
-        "B6": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B6.TIF",
-        "B7": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B7.TIF",
-        "B8": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B8.TIF",
-        "B9": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B9.TIF",
-        "B10": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B10.TIF",
-        "B11": "https://gcp-public-data-landsat.commondatastorage.googleapis.com/LC08/01/224/061/LC08_L1TP_224061_20210129_20210306_01_T2/LC08_L1TP_224061_20210129_20210306_01_T2_B11.TIF",
-    },
-}
-
-l8_l2_data_mock = MagicMock(
-    return_value=[
-        {
-            "spacecraft_id": "LANDSAT_8",
-            "sensor_id": '["OLI", "TIRS"]',
-            "product_id": "LC08_L2SP_168075_20150222_20200909_02_T1_SR",
-            "sensing_time": datetime.datetime(2015, 2, 22, 7, 48, 34, 713438),
-            "cloud_cover": 43.28,
-            "wrs_path": "168",
-            "wrs_row": "075",
-            "base_url": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_stac.json",
-            "links": {
+            "id": "LE07_L2SP_205031_20170105_20201008_02_T1_SR",
+            "collection_id": "landsat-c2l2-sr",
+            "datetime": datetime.datetime(
+                2017, 1, 5, 11, 22, 9, 205065, tzinfo=datetime.timezone.utc
+            ),
+            "properties": {
+                "created": "2021-07-25T20:15:49.234Z",
+                "updated": "2021-07-25T20:15:49.234Z",
+                "datetime": "2017-01-05T11:22:09.205065Z",
+                "platform": "LANDSAT_7",
+                "proj:epsg": 32629,
+                "proj:shape": [7251, 8221],
+                "instruments": ["ETM"],
+                "eo:cloud_cover": 18,
+                "proj:transform": [30, 0, 330585, 0, -30, 4733115],
+                "view:off_nadir": 0,
+                "landsat:wrs_row": "031",
+                "landsat:scene_id": "LE72050312017005NSG00",
+                "landsat:wrs_path": "205",
+                "landsat:wrs_type": "2",
+                "view:sun_azimuth": 159.54739131,
+                "landsat:correction": "L2SP",
+                "view:sun_elevation": 22.97050011,
+                "landsat:cloud_cover_land": 7,
+                "landsat:collection_number": "02",
+                "landsat:collection_category": "T1",
+            },
+            "assets": {
                 "red": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B4.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B3.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["data"],
-                    "title": "Red Band (B4)",
+                    "title": "Red Band (B3)",
                     "eo:bands": [
                         {
                             "gsd": 30,
-                            "name": "B4",
+                            "name": "B3",
                             "common_name": "red",
                             "center_wavelength": 0.65,
                         }
                     ],
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B4.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B3.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
-                    "description": "Collection 2 Level-2 Red Band (B4) Surface Reflectance",
-                    "file:checksum": "1340bb0109bbfee3a267edd3e038a3433385d8e636ba593a7833eee22f9a84f27ca0f2de51bc7be00f50e4c535bf539ffd2bad38c294a6a90216732c5f315879916e",
+                    "description": "Collection 2 Level-2 Red Band (B3) Surface Reflectance",
+                    "file:checksum": "1340e8f0e964b01cf6f69eb8aab4b710d5b61ee1506885b667209d09380655465695559864f6c55bd5d49cc6bcb205ce20bec9f4ea3a7cc990f255321983b05919df",
                 },
                 "blue": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B2.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B1.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["data"],
-                    "title": "Blue Band (B2)",
+                    "title": "Blue Band (B1)",
                     "eo:bands": [
                         {
                             "gsd": 30,
-                            "name": "B2",
+                            "name": "B1",
                             "common_name": "blue",
                             "center_wavelength": 0.48,
                         }
                     ],
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B2.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B1.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
-                    "description": "Collection 2 Level-2 Blue Band (B2) Surface Reflectance",
-                    "file:checksum": "1340236b2e1844d966a0b1033d84c20c5bc9cf11639ec69f0c5c2821c74a36c7eeb47f6e39219ebf6ad559939f1b75850dfff5ae685ff111102a3cdcc948bd3c62e2",
+                    "description": "Collection 2 Level-2 Blue Band (B1) Surface Reflectance",
+                    "file:checksum": "134019b5ee3de28dd94c63ad0bab65342666f71a383849101cca9d5a28526bfeb2ca45f4306298591186e40d54bc7277bd50d97d5cfbf1c081b480fd959f311c13d4",
                 },
                 "green": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B3.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B2.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["data"],
-                    "title": "Green Band (B3)",
+                    "title": "Green Band (B2)",
                     "eo:bands": [
                         {
                             "gsd": 30,
-                            "name": "B3",
+                            "name": "B2",
                             "common_name": "green",
                             "center_wavelength": 0.56,
                         }
                     ],
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B3.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B2.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
-                    "description": "Collection 2 Level-2 Green Band (B3) Surface Reflectance",
-                    "file:checksum": "13402208bb5b07cb8d526f87f09244477cba0826ffd717882e7c330ff7465b066befa3bf34f430d1ac46fd49d783bb5609ef2cacd20de28989be83e16cdd901218ff",
+                    "description": "Collection 2 Level-2 Green Band (B2) Surface Reflectance",
+                    "file:checksum": "13401bf58b6288d51dbc8616acb1dbaa70c2b7bd6ecedae742f682a4bf5d0f8eb6a92c431e52cd254411b59331313520afe43b3286bb38a4f586b0cf09668236d743",
                 },
                 "index": {
-                    "href": "https://landsatlook.usgs.gov/stac-browser/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1",
+                    "href": "https://landsatlook.usgs.gov/stac-browser/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1",
                     "type": "text/html",
                     "roles": ["metadata"],
                     "title": "HTML index page",
                 },
                 "nir08": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B5.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B4.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["data", "reflectance"],
-                    "title": "Near Infrared Band 0.8 (B5)",
+                    "title": "Near Infrared Band 0.8 (B4)",
                     "eo:bands": [
                         {
                             "gsd": 30,
-                            "name": "B5",
+                            "name": "B4",
                             "common_name": "nir08",
                             "center_wavelength": 0.86,
                         }
                     ],
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B5.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B4.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
-                    "description": "Collection 2 Level-2 Near Infrared Band 0.8 (B5) Surface Reflectance",
-                    "file:checksum": "134026c23a82dd9edb79aa34bfcd83e527adb0e0ddcf31c12ca574cd52c344bb292306603f5823cd9fbbda3eb9ddea1a30d07bcf9f42b2a47ed93dd3895f82eda5ec",
+                    "description": "Collection 2 Level-2 Near Infrared Band 0.8 (B4) Surface Reflectance",
+                    "file:checksum": "1340cbe432e9fc425f27c13e070236c1c1269cb1dd39e29ed4a2e0d2734624b7c1164db9ff6dc19a37898f054bbbdaa39aa900a151a72622ef50f8437f592593f2c7",
                 },
                 "swir16": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B6.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B5.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["data", "reflectance"],
-                    "title": "Short-wave Infrared Band 1.6 (B6)",
+                    "title": "Short-wave Infrared Band 1.6 (B5)",
                     "eo:bands": [
                         {
                             "gsd": 30,
-                            "name": "B6",
+                            "name": "B5",
                             "common_name": "swir16",
                             "center_wavelength": 1.6,
                         }
                     ],
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B6.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B5.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Short-wave Infrared Band 1.6 (B6) Surface Reflectance",
-                    "file:checksum": "1340c78755b2033dea2bcd6a5a09db85b5553fe5045d76fd741a116ab30f73704a6f3378b378efa8c77dd54a662e6219cfae4f5b67d7eb0197af9e8d6645fab6ad10",
+                    "file:checksum": "134044e382baab99457eff7953ac2543e7b0404aa81d2013e55ca0d03773b6815d50e2403669e548943276c6dd0eeb7f9303b607d9cd691b66a6e235d0e9952c6b81",
                 },
                 "swir22": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B7.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B7.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["data", "reflectance"],
                     "title": "Short-wave Infrared Band 2.2 (B7)",
@@ -465,61 +1155,390 @@ l8_l2_data_mock = MagicMock(
                     ],
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B7.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_B7.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Short-wave Infrared Band 2.2 (B7) Surface Reflectance",
-                    "file:checksum": "1340899f2371cd63517822d7d507eb18f452fd55e36383a442b50fbe88f65b74ae9a3cf7fc01ada617486b970d99d37f9487b1690c6271a66b150279de8c2b8ae745",
+                    "file:checksum": "1340a1dc075e7ef1ec30b96be3b1a8ac6c07fe656420eee054f25bd40bc20fe6071d1ace408eae3285d83ffc9c679945c0220159f4e5f3bc8d297fe9785aa74aaeed",
                 },
                 "ANG.txt": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_ANG.txt",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_ANG.txt",
                     "type": "text/plain",
                     "roles": ["metadata"],
                     "title": "Angle Coefficients File",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_ANG.txt",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_ANG.txt",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Angle Coefficients File (ANG)",
-                    "file:checksum": "13406d61c5a377327c807ebe6e826f4c8edb53c42215efb63d72c6cfc214c0e767f1bcb5e4f2e8daa15a78741c5b48500333f1b5e931badda68e4faa8dc97f396774",
+                    "file:checksum": "13403c830b9d5421ae209e91dbf145b427bec1efa3c8f2bf6bed079fd1ec30075d9b0128492106f91c155a793d6c2e74643ae2878732ee98107a6422badb6a740b1a",
                 },
                 "MTL.txt": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_MTL.txt",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_MTL.txt",
                     "type": "text/plain",
                     "roles": ["metadata"],
                     "title": "Product Metadata File",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_MTL.txt",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_MTL.txt",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Product Metadata File (MTL)",
-                    "file:checksum": "13404e4e3b5a5596cfe0e7582ec87019e31abcd228006749242cc5a4f1f87eaa8da482327bd9f6a67c576086ba03343945646f9a122b515b92e47f44aad952564edf",
+                    "file:checksum": "134023533665e269d5f797e87c160d345a092e9d357e81ad312fd5a192692aa47d8ff12e00fe120c19cd8eeddf42e658bf5a1cf4a371945cf2488a59efce3d869cce",
                 },
                 "MTL.xml": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_MTL.xml",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_MTL.xml",
                     "type": "application/xml",
                     "roles": ["metadata"],
                     "title": "Product Metadata File (xml)",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_MTL.xml",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_MTL.xml",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-1 Product Metadata File (xml)",
-                    "file:checksum": "13406bf9c1d68494a186316b6f828e684878f7706e1a2e8d5ea15c1ce30210cb75f9e0f1ff1b2030913450fc519797d5c58715b2332942081fa5a2ed904a58daa445",
+                    "file:checksum": "13403d984f4c5fb0917419332aee2171dafd337c47fa706242433c6724bbf86ae0e5f45e057e8585860cdfd33b6018bd73324b7cf832f04ab14f863d7c9459d4a742",
+                },
+                "MTL.json": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_MTL.json",
+                    "type": "application/json",
+                    "roles": ["metadata"],
+                    "title": "Product Metadata File (json)",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_MTL.json",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Product Metadata File (json)",
+                    "file:checksum": "1340941a5f8e93a8108601e7625b9fde5b43b5b1d36d479a3451638dacbf4e0ac15ff1822241e9d7348f3efc05b8f4d181ec88c338980b3f59dfc5b2bc4c5a22ee2d",
+                },
+                "cloud_qa": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_CLOUD_QA.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": [
+                        "metadata",
+                        "cloud",
+                        "cloud-shadow",
+                        "snow-ice",
+                        "water-mask",
+                    ],
+                    "title": "Cloud Quality Analysis Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_CLOUD_QA.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Cloud Quality Opacity Band Surface Reflectance",
+                    "file:checksum": "1340d51ff2ee8403f1faa9b78690d66e5563358535b43ad2cf42dd00ba990a71dfd2ddbb583bd2067ccf4f6d7bb77d59d862a6a410eb1aa4c6312d6e1bfd486bc7ae",
+                },
+                "qa_pixel": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_QA_PIXEL.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["cloud", "cloud-shadow", "snow-ice", "water-mask"],
+                    "title": "Pixel Quality Assessment Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_QA_PIXEL.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Pixel Quality Assessment Band Surface Reflectance",
+                    "file:checksum": "13402c10a19a59ec2a0e16e6c9bb601e80650dd4600e77d933b8140d0d09d9e67f3c24db0d8475947d6225d6b2e47722e6be64c6b0244fc18a82f0b512cf059ce838",
+                },
+                "qa_radsat": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_QA_RADSAT.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["saturation"],
+                    "title": "Radiometric Saturation Quality Assessment Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_QA_RADSAT.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Radiometric Saturation Quality Assessment Band Surface Reflectance",
+                    "file:checksum": "1340135bda775e46814213dc35bbc9c7a44c06af9604e899027eb4f87762a3a50e20668883f8d1e03a1ee7db20e1dbf22e42fbf2135c1362a5d0e821734d22214607",
+                },
+                "thumbnail": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_thumb_small.jpeg",
+                    "type": "image/jpeg",
+                    "roles": ["thumbnail"],
+                    "title": "Thumbnail image",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_thumb_small.jpeg",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "file:checksum": "13406d0c4d26c98c090e7e820e28e198a76ab09e6a58b59b43c618d78f606a3fd21407716fb59dd77647ddd59368eff0dff659ba2fc033c2965fbe523ec3766dcc7c",
+                },
+                "atmos_opacity": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_ATMOS_OPACITY.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Atmospheric Opacity Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_SR_ATMOS_OPACITY.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Atmospheric Opacity Band Surface Reflectance",
+                    "file:checksum": "13404576ac9bb30eff87779c3d08d267f2f2601d7f6c889ec777ba6634994fb1704e2d106d8f86ea3c58734d48d024137091fa775508b6b7a8fa3220b49c4bbe5364",
+                },
+                "reduced_resolution_browse": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_thumb_large.jpeg",
+                    "type": "image/jpeg",
+                    "roles": ["overview"],
+                    "title": "Reduced resolution browse image",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/205/031/LE07_L2SP_205031_20170105_20201008_02_T1/LE07_L2SP_205031_20170105_20201008_02_T1_thumb_large.jpeg",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "file:checksum": "1340aeeef624c3152207f7bb3bbc3beea5d7f4f2b4d1fcbd85529497dd6eeebda6e7ca32130abc039e9edc21f57e928a808cd244b7ab9b57a3622571c8b058aac737",
+                },
+            },
+        },
+        {
+            "id": "LC08_L2SP_204031_20170106_20200905_02_T1_SR",
+            "collection_id": "landsat-c2l2-sr",
+            "datetime": datetime.datetime(
+                2017, 1, 6, 11, 13, 55, 122499, tzinfo=datetime.timezone.utc
+            ),
+            "properties": {
+                "created": "2021-07-25T13:57:09.491Z",
+                "updated": "2021-07-25T13:57:09.491Z",
+                "datetime": "2017-01-06T11:13:55.122499Z",
+                "platform": "LANDSAT_8",
+                "proj:epsg": 32629,
+                "proj:shape": [7831, 7711],
+                "instruments": ["OLI", "TIRS"],
+                "eo:cloud_cover": 15.03,
+                "proj:transform": [30, 0, 468585, 0, -30, 4740615],
+                "view:off_nadir": 0,
+                "landsat:wrs_row": "031",
+                "landsat:scene_id": "LC82040312017006LGN02",
+                "landsat:wrs_path": "204",
+                "landsat:wrs_type": "2",
+                "view:sun_azimuth": 158.93560587,
+                "landsat:correction": "L2SP",
+                "view:sun_elevation": 22.92423803,
+                "landsat:cloud_cover_land": 17.27,
+                "landsat:collection_number": "02",
+                "landsat:collection_category": "T1",
+            },
+            "assets": {
+                "red": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B4.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Red Band (B4)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B4",
+                            "common_name": "red",
+                            "center_wavelength": 0.65,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B4.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Red Band (B4) Surface Reflectance",
+                    "file:checksum": "1340171960de7079ebb7d123c36713515cabcd0446cbaa8dc69875a8bcaf88e01cfc9bd134cd0af6987de9ce8c6427d09a08d911c484365ff4d75283f052da919503",
+                },
+                "blue": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B2.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Blue Band (B2)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B2",
+                            "common_name": "blue",
+                            "center_wavelength": 0.48,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B2.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Blue Band (B2) Surface Reflectance",
+                    "file:checksum": "1340b97fd1efea76fb1ead3ba6e179da73eb45fc36718e32812994ea0961b90daa04e553e6e246aa8050bba616576b60045efac1a1699c0e20d1a065700c471a4b08",
+                },
+                "green": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B3.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Green Band (B3)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B3",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B3.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Green Band (B3) Surface Reflectance",
+                    "file:checksum": "1340ab154eac9c0b4206214c48d32df68779f449ed8a4fec23bd54cb2583b03aa1d634708ba14004784107f1c56e13a7341cda1ec991b6cf644995ab313cb9922a90",
+                },
+                "index": {
+                    "href": "https://landsatlook.usgs.gov/stac-browser/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1",
+                    "type": "text/html",
+                    "roles": ["metadata"],
+                    "title": "HTML index page",
+                },
+                "nir08": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B5.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data", "reflectance"],
+                    "title": "Near Infrared Band 0.8 (B5)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B5",
+                            "common_name": "nir08",
+                            "center_wavelength": 0.86,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B5.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Near Infrared Band 0.8 (B5) Surface Reflectance",
+                    "file:checksum": "13402c6daab12bafd4b450f9d7eeef9a5b10da3d03ace3611c55d63630958575e6f3d6989f0161b5c36c409a70727d5b76d58b2b0b3fe573c61169312deb824518d4",
+                },
+                "swir16": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B6.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data", "reflectance"],
+                    "title": "Short-wave Infrared Band 1.6 (B6)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B6",
+                            "common_name": "swir16",
+                            "center_wavelength": 1.6,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B6.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Short-wave Infrared Band 1.6 (B6) Surface Reflectance",
+                    "file:checksum": "1340dfd9be925a933b71c0e135d7b61b9f215c8794652b703c21d871475ee9569bc169673e925e9be9293706b12096460b4dc2d081afed8ee59b6bd5eb3df0627b93",
+                },
+                "swir22": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B7.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data", "reflectance"],
+                    "title": "Short-wave Infrared Band 2.2 (B7)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B7",
+                            "common_name": "swir22",
+                            "center_wavelength": 2.2,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B7.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Short-wave Infrared Band 2.2 (B7) Surface Reflectance",
+                    "file:checksum": "13409f319256d1ffaf330a98a506c0220628e0dfa50c582a14e5bae68d3eb453ec31e083cfab25dc9c331128445c4c25dc8a11036fdd466e7e192701bd4dd9e8753e",
+                },
+                "ANG.txt": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_ANG.txt",
+                    "type": "text/plain",
+                    "roles": ["metadata"],
+                    "title": "Angle Coefficients File",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_ANG.txt",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Angle Coefficients File (ANG)",
+                    "file:checksum": "134002e38ee39282aa05ece8e0c506538c1888e64d84cb4cc61f95480f882f0580b7596e8c7e0e3b64adbb15a7701371dcf9a49efcd51b15ca046696ad07d2c1f43f",
+                },
+                "MTL.txt": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_MTL.txt",
+                    "type": "text/plain",
+                    "roles": ["metadata"],
+                    "title": "Product Metadata File",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_MTL.txt",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Product Metadata File (MTL)",
+                    "file:checksum": "13401b7c970108f8451b7834862b5f3f4a83575095b51585e88fe2345b489fc349f73a8f1df7ac395e6764d77d0f545fb2a8dfbbdae1c97ccef5eebe65ebd556487b",
+                },
+                "MTL.xml": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_MTL.xml",
+                    "type": "application/xml",
+                    "roles": ["metadata"],
+                    "title": "Product Metadata File (xml)",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_MTL.xml",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-1 Product Metadata File (xml)",
+                    "file:checksum": "134045e49f35ae92ca981f8ef99b391eef4b5c1e007fd9a968339721e47e5209add18dafd636a79242acbd040d5ba31df5019e53383f2520bc95fbe4782f85e2286d",
                 },
                 "coastal": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B1.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B1.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["data"],
                     "title": "Coastal/Aerosol Band (B1)",
@@ -533,128 +1552,437 @@ l8_l2_data_mock = MagicMock(
                     ],
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B1.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B1.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Coastal/Aerosol Band (B1) Surface Reflectance",
-                    "file:checksum": "1340c456557616ca467af090743e8a120f504909bfd1131d15e17cc0561808957f659b7591467697283c6d093cab926b2ad92b6a074c51a1aedd7fd9b5cd7e7c4e82",
+                    "file:checksum": "1340e619b571d8645679a4e80acd958315d34c8265f58535c18e617418a2f9115be4b0f52a17e7bf8d12f218da1ac9f950c7e81a5e5e3183edd6c1d6d7af96efad27",
                 },
                 "MTL.json": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_MTL.json",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_MTL.json",
                     "type": "application/json",
                     "roles": ["metadata"],
                     "title": "Product Metadata File (json)",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_MTL.json",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_MTL.json",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Product Metadata File (json)",
-                    "file:checksum": "1340ce06bf0b60bad650869141f35e80587dc141b472cc23ad1ee4182323357e48a482049de1c35e6f02997d552ce1d38639a4a653c0c9cd8ee3ff1b0ad8fa591ed6",
+                    "file:checksum": "13402a1d1278b779770d417181694cedb734e995816ad94fc75cb5e9f0763da097970532ae1bbe6900e27818d2812f5caea42b134d7b4240770666336dfff21174f2",
                 },
                 "qa_pixel": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_QA_PIXEL.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_QA_PIXEL.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["cloud", "cloud-shadow", "snow-ice", "water-mask"],
                     "title": "Pixel Quality Assessment Band",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_QA_PIXEL.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_QA_PIXEL.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Pixel Quality Assessment Band Surface Reflectance",
-                    "file:checksum": "1340cc76f48636e56621df51112044c0c3b538c7ee878b956920fc802e28f2978143051b18384ddd0b80c4895acf56aeb4cfe7e130353f8da7be359e8c7176682c36",
+                    "file:checksum": "13400a1300c196831041b0b2ba0a69f9fce5a2cd05405c8a8ae14def4ae353c8add4aa0e1e2132b64202689d4370f40ae328042db7868dfe38fe491e7ca9b239b28e",
                 },
                 "qa_radsat": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_QA_RADSAT.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_QA_RADSAT.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["saturation"],
                     "title": "Radiometric Saturation Quality Assessment Band",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_QA_RADSAT.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_QA_RADSAT.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Radiometric Saturation Quality Assessment Band Surface Reflectance",
-                    "file:checksum": "1340bfc8dae2822ad1291b92f06d445db689492660dfa17305f11d5bc8bfec78169f751ea7887f6f83b148d329018225a4d1e8f9ea6869d4b8a7ffed406f275a445f",
+                    "file:checksum": "13408c39074aa270f1797455859eaa8423966eb34aeb1d5120e9a0588528a860e02a09b5251396734dc8cf05077b6d97ab95ee68418749153609d7cd5ef4a7112926",
                 },
                 "thumbnail": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_thumb_small.jpeg",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_thumb_small.jpeg",
                     "type": "image/jpeg",
                     "roles": ["thumbnail"],
                     "title": "Thumbnail image",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_thumb_small.jpeg",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_thumb_small.jpeg",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
-                    "file:checksum": "1340413198a45ea1c1360f95cbef9e8fd4b73cb6623909eea22412a572e0d8297d9613d79c14dcd1716435add750bf1d4fcb32bb03799eac5fc1ac1f792a21cd8113",
+                    "file:checksum": "134024c3536faee149c0f5d232b80f71f264430b9dc46a75e1559c9f5642175f05adbb1a65cdf4677517045ace8bb51d4b50763f421b0cfc6f99c5448225d7b8e6d6",
                 },
                 "qa_aerosol": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_QA_AEROSOL.TIF",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_QA_AEROSOL.TIF",
                     "type": "image/vnd.stac.geotiff; cloud-optimized=true",
                     "roles": ["metadata", "data-mask", "water-mask"],
                     "title": "Aerosol Quality Analysis Band",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_QA_AEROSOL.TIF",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_QA_AEROSOL.TIF",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
                     "description": "Collection 2 Level-2 Aerosol Quality Analysis Band (ANG) Surface Reflectance",
-                    "file:checksum": "134078578f7cb60183ff695b338d9fd1773b7cc0f36035b0e70ea6170bca3cfec6c78d9fef9560eb7ae2d0e155b7263fb9f0b07eb9449a028d9e66e060bb01dca6e2",
+                    "file:checksum": "1340e095d98400a38107278b25aa8a56de44cae58d8e178b5fd8fbff22e003a791df32e25ead1de5966bb842cd082aedd765ded02681f8689956a353ffcec7d377e5",
                 },
                 "reduced_resolution_browse": {
-                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_thumb_large.jpeg",
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_thumb_large.jpeg",
                     "type": "image/jpeg",
                     "roles": ["overview"],
                     "title": "Reduced resolution browse image",
                     "alternate": {
                         "s3": {
-                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_thumb_large.jpeg",
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_thumb_large.jpeg",
                             "storage:platform": "AWS",
                             "storage:requester_pays": True,
                         }
                     },
-                    "file:checksum": "1340d63dd34c6c5bf50083983e4e857a06a7f646c15c35db47759fb82d19c4d45f2c1d7a7453bbf79b81fea3993f94c2ea35b49df6709a05a4ee7d5e4738abfa3f7a",
+                    "file:checksum": "134057a121aaece516a7c36b8a3340431482c53c5fc07cf6d592bd0086c7e40cda8f6fd56219b366748157231bc6664a2ce10211f0adaed88e952c132ee88b357a77",
                 },
             },
-        }
+        },
+        {
+            "id": "LE07_L2SP_204031_20170130_20200901_02_T2_SR",
+            "collection_id": "landsat-c2l2-sr",
+            "datetime": datetime.datetime(
+                2017, 1, 30, 11, 15, 43, 856138, tzinfo=datetime.timezone.utc
+            ),
+            "properties": {
+                "created": "2021-07-24T11:40:43.404Z",
+                "updated": "2021-07-24T11:40:43.404Z",
+                "datetime": "2017-01-30T11:15:43.856138Z",
+                "platform": "LANDSAT_7",
+                "proj:epsg": 32629,
+                "proj:shape": [7151, 8141],
+                "instruments": ["ETM"],
+                "eo:cloud_cover": 100,
+                "proj:transform": [30, 0, 460785, 0, -30, 4731615],
+                "view:off_nadir": 0,
+                "landsat:wrs_row": "031",
+                "landsat:scene_id": "LE72040312017030NSG00",
+                "landsat:wrs_path": "204",
+                "landsat:wrs_type": "2",
+                "view:sun_azimuth": 155.8894353,
+                "landsat:correction": "L2SP",
+                "view:sun_elevation": 27.19500623,
+                "landsat:cloud_cover_land": 100,
+                "landsat:collection_number": "02",
+                "landsat:collection_category": "T2",
+            },
+            "assets": {
+                "red": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B3.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Red Band (B3)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B3",
+                            "common_name": "red",
+                            "center_wavelength": 0.65,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B3.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Red Band (B3) Surface Reflectance",
+                    "file:checksum": "1340348b13ce0a6d76602565d0fd92b92aeaf22e611224efd3000b82d8b16cb268a0056073d873627c8192e76456156ccb18c3ef78e3f567e6557a600c3e2c2c06c3",
+                },
+                "blue": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B1.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Blue Band (B1)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B1",
+                            "common_name": "blue",
+                            "center_wavelength": 0.48,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B1.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Blue Band (B1) Surface Reflectance",
+                    "file:checksum": "13400aca8e6563fa5a112c21f62742610210b71c2243a92c87de77d21ac58ad6d7c8db2adb78214c611072df85aca044864d663578f0c07f5dcd47eeb9aba070d2dc",
+                },
+                "green": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B2.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Green Band (B2)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B2",
+                            "common_name": "green",
+                            "center_wavelength": 0.56,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B2.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Green Band (B2) Surface Reflectance",
+                    "file:checksum": "134052fafbf70cead034ade1121bed8da277efdae0a87939f4fee4f59de735898466bfad2e4f57ef5ed13899fe1a4b99e604c003e3979d83a555710edcbd5b6edab0",
+                },
+                "index": {
+                    "href": "https://landsatlook.usgs.gov/stac-browser/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2",
+                    "type": "text/html",
+                    "roles": ["metadata"],
+                    "title": "HTML index page",
+                },
+                "nir08": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B4.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data", "reflectance"],
+                    "title": "Near Infrared Band 0.8 (B4)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B4",
+                            "common_name": "nir08",
+                            "center_wavelength": 0.86,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B4.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Near Infrared Band 0.8 (B4) Surface Reflectance",
+                    "file:checksum": "13404ca33e1fb202fe8f6c37d6e87df40b89a7fa2fbe98f13246f767611dc10ded67016225dd0bc99c54c5c57e2d2e4b24645183309f30c08ef7e8ed20f2a921cbe6",
+                },
+                "swir16": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B5.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data", "reflectance"],
+                    "title": "Short-wave Infrared Band 1.6 (B5)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B5",
+                            "common_name": "swir16",
+                            "center_wavelength": 1.6,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B5.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Short-wave Infrared Band 1.6 (B6) Surface Reflectance",
+                    "file:checksum": "13408fb1bf17381186c5f8929d51958846f1cb6d3e3e73bbcacd9b1339f22137f2db9c9b284f6ed84ac223f8f3ff4bc49cbf9359e8cadfbf55b42532a04822c24f85",
+                },
+                "swir22": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B7.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data", "reflectance"],
+                    "title": "Short-wave Infrared Band 2.2 (B7)",
+                    "eo:bands": [
+                        {
+                            "gsd": 30,
+                            "name": "B7",
+                            "common_name": "swir22",
+                            "center_wavelength": 2.2,
+                        }
+                    ],
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_B7.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Short-wave Infrared Band 2.2 (B7) Surface Reflectance",
+                    "file:checksum": "1340909995932b0135c4da2b44bd4c376d9fe5256d9f39a100db3b52e288d11b7653b022cd4b6b3bc22baaeccaf9ba96d7f7fbc850581c493ebcf4c2e42b8f9c3eff",
+                },
+                "ANG.txt": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_ANG.txt",
+                    "type": "text/plain",
+                    "roles": ["metadata"],
+                    "title": "Angle Coefficients File",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_ANG.txt",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Angle Coefficients File (ANG)",
+                    "file:checksum": "1340cd83bce0b4978a88833f8b10a9af636a8dd1e6eaaa410b080ac0391467da1803406c4b0e20dbbd3d7a30180c399ce4f51e64b411a9cbda58fb564e5f2df14826",
+                },
+                "MTL.txt": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_MTL.txt",
+                    "type": "text/plain",
+                    "roles": ["metadata"],
+                    "title": "Product Metadata File",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_MTL.txt",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Product Metadata File (MTL)",
+                    "file:checksum": "1340ca47f687340540dfaa21ee4fa820b81d4c6640b2b25a33ae77cc42dd11bc3e06d7d1a181d257a0270f067bc2c13ea7b204b9804890c1eebc4c3d931cd222125f",
+                },
+                "MTL.xml": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_MTL.xml",
+                    "type": "application/xml",
+                    "roles": ["metadata"],
+                    "title": "Product Metadata File (xml)",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_MTL.xml",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-1 Product Metadata File (xml)",
+                    "file:checksum": "13401d08fb4ac38585bb356d96351b3db8bad1b515fbd5a61347a2f6bba74dd2cc1b5ede55304b64461e44162217b88d4c90c8511eb8a5e55ed3455edce547387a7d",
+                },
+                "MTL.json": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_MTL.json",
+                    "type": "application/json",
+                    "roles": ["metadata"],
+                    "title": "Product Metadata File (json)",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_MTL.json",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Product Metadata File (json)",
+                    "file:checksum": "13406cae6575ebbcc28787e47a18019f0dce48e4380fedcf4f0a6675b6d35a6cacd5ac6b089a41917a8add31933c8c238633a48f5fd3663c4507b45fadc7ea91f9b0",
+                },
+                "cloud_qa": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_CLOUD_QA.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": [
+                        "metadata",
+                        "cloud",
+                        "cloud-shadow",
+                        "snow-ice",
+                        "water-mask",
+                    ],
+                    "title": "Cloud Quality Analysis Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_CLOUD_QA.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Cloud Quality Opacity Band Surface Reflectance",
+                    "file:checksum": "1340b97c2e96ad66782325270ea53061e236f2768904ead212523fc93473dad4a7d2c7ceb9477e8aa05860b7e184cf23fb758da148ba1d2518374fa035b3fa061f55",
+                },
+                "qa_pixel": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_QA_PIXEL.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["cloud", "cloud-shadow", "snow-ice", "water-mask"],
+                    "title": "Pixel Quality Assessment Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_QA_PIXEL.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Pixel Quality Assessment Band Surface Reflectance",
+                    "file:checksum": "134060a6cc7bc7c15d2e541328ee61a755396924cf415566e6b2ff8fe2b3027e5c0088181ab212fffdf3b8d790770b4eb94d6fc542110be478fba575fb8c9188cee7",
+                },
+                "qa_radsat": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_QA_RADSAT.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["saturation"],
+                    "title": "Radiometric Saturation Quality Assessment Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_QA_RADSAT.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Radiometric Saturation Quality Assessment Band Surface Reflectance",
+                    "file:checksum": "13403c58791f514b3482c528ada0cc727f06904d685c286d3bfb05401364b6015954da357bd79e979aabc275768b6b8e728040a8d4084a30c0c0ea26a1ba26f613eb",
+                },
+                "thumbnail": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_thumb_small.jpeg",
+                    "type": "image/jpeg",
+                    "roles": ["thumbnail"],
+                    "title": "Thumbnail image",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_thumb_small.jpeg",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "file:checksum": "134029cf86f4a4acfc05d3e884c32f29db3b6f33bc3ec1635f0c2ef8b20d199dceff5b4045a93bb82b8f128a257ff67151e7db8b1b70698fef45af1b747cce96d719",
+                },
+                "atmos_opacity": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_ATMOS_OPACITY.TIF",
+                    "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+                    "roles": ["data"],
+                    "title": "Atmospheric Opacity Band",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_SR_ATMOS_OPACITY.TIF",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "description": "Collection 2 Level-2 Atmospheric Opacity Band Surface Reflectance",
+                    "file:checksum": "134017d52b714956e8beda45ebe1373d6cc472c28a330a9da3e0028817b44cfea40c21f18941389a20cc92fffe6d9526a2d9442302896ac252a11a4be78ac64069ea",
+                },
+                "reduced_resolution_browse": {
+                    "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_thumb_large.jpeg",
+                    "type": "image/jpeg",
+                    "roles": ["overview"],
+                    "title": "Reduced resolution browse image",
+                    "alternate": {
+                        "s3": {
+                            "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2017/204/031/LE07_L2SP_204031_20170130_20200901_02_T2/LE07_L2SP_204031_20170130_20200901_02_T2_thumb_large.jpeg",
+                            "storage:platform": "AWS",
+                            "storage:requester_pays": True,
+                        }
+                    },
+                    "file:checksum": "1340052d5770e15c0f79064799223a75bf2cb74cfa9c695616b1d4dac37a4a38e73f09f7d88a2307056337224b193b5cfd049b015c9f9ef4c82c76527ceb9786a4a3",
+                },
+            },
+        },
     ]
 )
 
-l8_l2_expected_scene = {
-    "spacecraft_id": "LANDSAT_8",
-    "sensor_id": '["OLI", "TIRS"]',
-    "product_id": "LC08_L2SP_168075_20150222_20200909_02_T1_SR",
-    "sensing_time": datetime.datetime(2015, 2, 22, 7, 48, 34, 713438),
-    "cloud_cover": 43.28,
-    "wrs_path": "168",
-    "wrs_row": "075",
-    "base_url": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_stac.json",
-    "bands": {
-        "B4": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B4.TIF",
-        "B2": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B2.TIF",
-        "B3": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B3.TIF",
-        "B5": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B5.TIF",
-        "B6": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B6.TIF",
-        "B7": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B7.TIF",
-        "B1": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_SR_B1.TIF",
-        "QA_PIXEL": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_QA_PIXEL.TIF",
-        "QA_SAT": "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2015/168/075/LC08_L2SP_168075_20150222_20200909_02_T1/LC08_L2SP_168075_20150222_20200909_02_T1_QA_RADSAT.TIF",
-    },
-}
+empty_data_mock = MagicMock(return_value=[])
 
 sample_geojson = {
     "type": "FeatureCollection",

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -22,18 +22,15 @@ def mock_search_data(
     level=None,
     limit=10,
     sort="sensing_time",
-    sensor=None,
+    bands=None,
 ):
     response = []
     for i in range(3):
         response.append(
             {
-                "product_id": "S2A_MSIL2A_20200130T112311_{}".format(i),
-                "granule_id": "L2A_T29SMC_A024058_20200130T112435_{}".format(i),
+                "id": "S2A_MSIL2A_20200130T112311_{}".format(i),
                 "sensing_time": datetime.datetime(2020, 1, 20 + i, 11, 30, 39, 918000),
-                "mgrs_tile": "29SMC",
                 "cloud_cover": 70.091273,
-                "base_url": "gs://data-sentinel-2/S2A_{}.SAFE".format(i),
                 "bands": {
                     "B01": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
                     "B02": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
@@ -55,12 +52,9 @@ def mock_search_data(
     # Append zero scene.
     response.append(
         {
-            "product_id": "S2A_MSIL2A_20200130T112311_{}".format(i),
-            "granule_id": "L2A_T29SMC_A024058_20200130T112435_{}".format(i),
+            "id": "S2A_MSIL2A_20200130T112311_{}".format(i),
             "sensing_time": datetime.datetime(2020, 2, 1, 11, 30, 39, 918000),
-            "mgrs_tile": "29SMC",
             "cloud_cover": 70.091273,
-            "base_url": "gs://data-sentinel-2/S2A_{}.SAFE".format(i),
             "bands": {
                 "B01": os.path.join(os.path.dirname(__file__), "data/B02.tif"),
                 "B02": os.path.join(os.path.dirname(__file__), "data/B02.tif"),

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,37 +1,8 @@
 import unittest
 from unittest.mock import patch
 
-from pixels.const import (
-    L1_DATES,
-    L2_DATES,
-    L3_DATES,
-    L4_DATES,
-    L5_DATES,
-    L7_DATES,
-    L8_DATES,
-)
 from pixels.search import search_data
-from tests.scenarios import (
-    empty_data_mock,
-    l1_data_mock,
-    l1_expected_scene,
-    l2_data_mock,
-    l2_expected_scene,
-    l3_data_mock,
-    l3_expected_scene,
-    l4_data_mock,
-    l4_expected_scene,
-    l5_data_mock,
-    l5_expected_scene,
-    l7_data_mock,
-    l7_expected_scene,
-    l8_data_mock,
-    l8_expected_scene,
-    l8_l2_data_mock,
-    l8_l2_expected_scene,
-    s2_expected_scene,
-    sentinel_2_data_mock,
-)
+from tests.scenarios import empty_data_mock, landsat_data_mock, sentinel_2_data_mock
 
 # AOI.
 geojson = {
@@ -87,8 +58,6 @@ geojson_MZ = {
 
 
 class SearchTest(unittest.TestCase):
-    maxDiff = None
-
     @patch("pixels.search.execute_query", sentinel_2_data_mock)
     def test_result_sentinel(self):
         actual = search_data(
@@ -96,142 +65,43 @@ class SearchTest(unittest.TestCase):
             start="2020-12-01",
             end="2021-01-01",
             maxcloud=100,
-            limit=1,
+            limit=2,
             level="L2A",
             platforms="SENTINEL_2",
+            bands=["B04", "B8A", "B02"],
         )
-        self.assertDictEqual(actual[0], s2_expected_scene)
+        self.assertEqual(actual[0]["id"], "S2A_29TNG_20170128_0_L2A")
+        self.assertEqual(
+            actual[0]["bands"]["B8A"],
+            "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/29/T/NG/2017/1/S2A_29TNG_20170128_0_L2A/B8A.tif",
+        )
 
-    @patch("pixels.search.execute_query", empty_data_mock)
-    def test_level(self):
+    @patch("pixels.search.execute_query", landsat_data_mock)
+    def test_result_landsat(self):
         actual = search_data(
             geojson,
             start="2020-12-01",
             end="2021-01-01",
             maxcloud=100,
-            limit=1,
-            level="L3",
-            platforms="SENTINEL_2",
-        )
-        self.assertEqual(actual, [])
-
-    @patch("pixels.search.execute_query", empty_data_mock)
-    def test_date(self):
-        actual = search_data(
-            geojson,
-            start="2020-12-01",
-            end="2021-01-01",
-            maxcloud=100,
-            limit=1,
-            platforms="LANDSAT_1",
-        )
-        self.assertEqual(actual, [])
-
-    @patch("pixels.search.execute_query", empty_data_mock)
-    def test_platform(self):
-        actual = search_data(
-            geojson,
-            start="2020-12-01",
-            end="2021-01-01",
-            maxcloud=100,
-            limit=1,
-            platforms="Landsat_1",
-        )
-        self.assertEqual(actual, [])
-
-    @patch("pixels.search.execute_query", l1_data_mock)
-    def test_result_l1(self):
-        actual = search_data(
-            geojson,
-            start=L1_DATES[0],
-            end=L1_DATES[1],
-            maxcloud=100,
-            limit=1,
-            platforms="LANDSAT_1",
-        )
-        self.assertDictEqual(actual[0], l1_expected_scene)
-
-    @patch("pixels.search.execute_query", l2_data_mock)
-    def test_result_l2(self):
-        actual = search_data(
-            geojson,
-            start=L2_DATES[0],
-            end=L2_DATES[1],
-            maxcloud=100,
-            limit=1,
-            platforms="LANDSAT_2",
-        )
-        self.assertDictEqual(actual[0], l2_expected_scene)
-
-    @patch("pixels.search.execute_query", l3_data_mock)
-    def test_result_l3(self):
-        actual = search_data(
-            geojson,
-            start=L3_DATES[0],
-            end=L3_DATES[1],
-            maxcloud=100,
-            limit=1,
-            platforms="LANDSAT_3",
-        )
-        self.assertDictEqual(actual[0], l3_expected_scene)
-
-    @patch("pixels.search.execute_query", l4_data_mock)
-    def test_result_l4(self):
-        actual = search_data(
-            geojson,
-            start=L4_DATES[0],
-            end=L4_DATES[1],
-            maxcloud=100,
-            limit=1,
-            platforms="LANDSAT_4",
-        )
-        self.assertDictEqual(actual[0], l4_expected_scene)
-
-    @patch("pixels.search.execute_query", l5_data_mock)
-    def test_result_l5(self):
-        actual = search_data(
-            geojson,
-            start=L5_DATES[0],
-            end=L5_DATES[1],
-            maxcloud=100,
-            limit=1,
-            platforms="LANDSAT_5",
-        )
-        self.assertDictEqual(actual[0], l5_expected_scene)
-
-    @patch("pixels.search.execute_query", l7_data_mock)
-    def test_result_l7(self):
-        actual = search_data(
-            geojson,
-            start=L7_DATES,
-            end="2020-01-31",
-            maxcloud=100,
-            limit=1,
-            platforms="LANDSAT_7",
-        )
-        self.assertDictEqual(actual[0], l7_expected_scene)
-
-    @patch("pixels.search.execute_query", l8_data_mock)
-    def test_result_l8(self):
-        actual = search_data(
-            geojson,
-            start=L8_DATES,
-            end="2021-01-31",
-            maxcloud=100,
-            limit=1,
+            limit=2,
             platforms="LANDSAT_8",
+            bands=["B2", "B4", "B5"],
         )
-        self.assertDictEqual(actual[0], l8_expected_scene)
+        self.assertEqual(actual[0]["id"], "LC08_L2SP_204031_20170106_20200905_02_T1_SR")
+        self.assertEqual(
+            actual[0]["bands"]["B5"],
+            "s3://usgs-landsat/collection02/level-2/standard/oli-tirs/2017/204/031/LC08_L2SP_204031_20170106_20200905_02_T1/LC08_L2SP_204031_20170106_20200905_02_T1_SR_B5.TIF",
+        )
 
-    @patch("pixels.search.execute_query", l8_l2_data_mock)
-    def test_result_ls_l2(self):
+    @patch("pixels.search.execute_query", empty_data_mock)
+    def test_result_empty(self):
         actual = search_data(
-            geojson_MZ,
-            start=L8_DATES,
-            end="2015-03-01",
+            geojson,
+            start="2020-12-01",
+            end="2021-01-01",
             maxcloud=100,
-            limit=1,
+            limit=2,
             platforms="LANDSAT_8",
-            level="L2",
+            bands=["B99"],
         )
-        self.assertDictEqual(actual[0], l8_l2_expected_scene)
+        self.assertEqual(actual, [])

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -5,7 +5,6 @@ import shutil
 import tempfile
 import unittest
 import zipfile
-from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import numpy
@@ -45,34 +44,23 @@ def write_temp_raster(
     return raster.name
 
 
-l8_return = MagicMock(
-    return_value={
-        "B1": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
-        "B2": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
-    }
-)
-
 l8_data_mock = MagicMock(
     return_value=[
         {
-            "product_id": "LC08_L1TP_205032_20201121_20201122_01_T1",
-            "granule_id": None,
+            "id": "LC08_L1TP_205032_20201121_20201122_01_T1",
             "sensing_time": datetime.datetime(2020, 11, 21, 11, 20, 37, 137788),
-            "mgrs_tile": None,
-            "cloud_cover": Decimal("0.01"),
-            "wrs_path": 85217265,
-            "wrs_row": 85217265,
-            "base_url": "gs://gcp-public-data-landsat/LC08/01/205/032/LC08_L1TP_205032_20201121_20201122_01_T1",
+            "bands": {
+                "B1": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
+                "B2": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
+            },
         },
         {
-            "product_id": "LC08_L1TP_205032_20201121_20201122_01_T1",
-            "granule_id": None,
+            "id": "LC08_L1TP_205032_20201121_20201122_01_T1",
             "sensing_time": datetime.datetime(2020, 11, 20, 11, 20, 37, 137788),
-            "mgrs_tile": None,
-            "cloud_cover": Decimal("0.01"),
-            "wrs_path": 85217265,
-            "wrs_row": 85217265,
-            "base_url": "gs://gcp-public-data-landsat/LC08/01/205/032/LC08_L1TP_205032_20201121_20201122_01_T1",
+            "bands": {
+                "B1": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
+                "B2": os.path.join(os.path.dirname(__file__), "data/B01.tif"),
+            },
         },
     ]
 )
@@ -229,8 +217,7 @@ class TestUtils(unittest.TestCase):
         obj.pop("assets")
         self.assertEqual(obj, self.item_example)
 
-    @patch("pixels.search.execute_query", l8_data_mock)
-    @patch("pixels.search.format_ls_c1_band", l8_return)
+    @patch("pixels.mosaic.search_data", l8_data_mock)
     def test_collect_from_catalog_subsection(self):
         catalog = parse_data(self.zip_file.name, True, reference_date="2020-01-01")
         catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)


### PR DESCRIPTION
Change core search logic to use only the pxsearch STAC database 🤖 🎉 

This will make the `eo_catalog` database obsolete and unify the search functionality into a fully external service. Review with care as this is a deep change.

I ran this multiple times locally and the results were good 🗺️ 

Once this is merged, we might consider to move the search module directly into pxsearch and install pxsearch into pixels. But that needs to be evaluated carefully.