### PR TITLE
Fix Empty search

### DIFF
--- a/pixels/generator/stac.py
+++ b/pixels/generator/stac.py
@@ -663,6 +663,8 @@ def get_and_write_raster_from_item(
     config = prepare_pixels_config(item, input_config)
     out_path = os.path.join(x_folder, "data", f"pixels_{str(item.id)}")
     configs = configure_multi_time_bubbles(config, out_path, item, overwrite)
+    if configs is None:
+        return
     # Run pixels.
     out_paths = []
     for config in configs:


### PR DESCRIPTION
When the search configs comes as None, the function wont go forward.
This happen when there is no configuration found, or when all images have been downloaded.
