### PR TITLE
fix(mosaic): add start date to latest pixel in pixel stack configuration

### DIFF
--- a/pixels/mosaic.py
+++ b/pixels/mosaic.py
@@ -341,6 +341,7 @@ def configure_pixel_stack(
                 pool_bands,
                 maxcloud,
                 level,
+                step[0],
             )
             for step in timeseries_steps(start, end, interval, interval_step)
         ]


### PR DESCRIPTION
This is relevant for collections where the time interval is short.