### PR TITLE
Geometry in colleting

### DIFF
--- a/pixels/generator/stac.py
+++ b/pixels/generator/stac.py
@@ -451,19 +451,13 @@ def build_geometry_geojson(item):
         geojson: dict
             Dictionary containing the bounding box from input raster.
     """
-    coords = item.geometry["coordinates"]
-    if len(np.array(coords).shape) != 3:
-        coords = coords[0][:1]
     geojson = {
         "type": "FeatureCollection",
         "crs": {"init": "EPSG:" + str(item.properties["proj:epsg"])},
         "features": [
             {
                 "type": "Feature",
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": coords,
-                },
+                "geometry": {**item.geometry},
             },
         ],
     }


### PR DESCRIPTION
I am not sure why, but in collecting the geometry used was limited to the 1st polygon that would appear in the geometry. and the definition was forcing to be just a Polygon.
This allow for MultiPolygons usage.

I propose this change to allow for other types to be used. I have tested with quite complex multipoligons and it is working very well