### PR TITLE
Solve scipy and rasterio dependency issues

### DIFF
--- a/batch/docker/requirements.in
+++ b/batch/docker/requirements.in
@@ -12,7 +12,7 @@ pyproj==3.2.1
 h5py
 tensorflow-addons==0.16.1
 sentry-sdk
-rasterio
+rasterio==1.2.10
 backoff
 structlog
 structlog-sentry

--- a/batch/docker/requirements.txt
+++ b/batch/docker/requirements.txt
@@ -15,13 +15,13 @@ attrs==21.4.0
     #   fiona
     #   jsonschema
     #   rasterio
-awscli==1.25.22
+awscli==1.25.24
     # via -r ./batch/docker/requirements.in
 backoff==2.1.2
     # via -r ./batch/docker/requirements.in
-boto3==1.24.22
+boto3==1.24.24
     # via -r ./batch/docker/requirements.in
-botocore==1.27.22
+botocore==1.27.24
     # via
     #   awscli
     #   boto3
@@ -89,6 +89,7 @@ numpy==1.23.0
     #   pandas
     #   pygeos
     #   rasterio
+    #   scipy
     #   snuggs
 packaging==21.3
     # via geopandas
@@ -139,6 +140,8 @@ s3transfer==0.6.0
     # via
     #   awscli
     #   boto3
+scipy==1.8.1
+    # via -r ./batch/docker/requirements.in
 scramp==1.4.1
     # via pg8000
 sentry-sdk==1.6.0
@@ -176,7 +179,7 @@ typeguard==2.13.3
     # via tensorflow-addons
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.9
+urllib3==1.26.10
     # via
     #   -r ./batch/docker/requirements.in
     #   botocore

--- a/batch/docker/tensorflow_requirements.txt
+++ b/batch/docker/tensorflow_requirements.txt
@@ -4,23 +4,23 @@
 #
 #    pip-compile --output-file=./batch/docker/tensorflow_requirements.txt ./batch/docker/tensorflow_requirements.in
 #
-absl-py==1.0.0
+absl-py==1.1.0
     # via
     #   tensorboard
     #   tensorflow
 astunparse==1.6.3
     # via tensorflow
-cachetools==5.0.0
+cachetools==5.2.0
     # via google-auth
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 flatbuffers==2.0
     # via tensorflow
 gast==0.4.0
     # via tensorflow
-google-auth==2.6.0
+google-auth==2.9.0
     # via
     #   google-auth-oauthlib
     #   tensorboard
@@ -28,25 +28,25 @@ google-auth-oauthlib==0.4.6
     # via tensorboard
 google-pasta==0.2.0
     # via tensorflow
-grpcio==1.44.0
+grpcio==1.47.0
     # via
     #   tensorboard
     #   tensorflow
-h5py==3.6.0
+h5py==3.7.0
     # via tensorflow
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via markdown
 keras==2.7.0
     # via tensorflow
 keras-preprocessing==1.1.2
     # via tensorflow
-libclang==13.0.0
+libclang==14.0.1
     # via tensorflow
-markdown==3.3.6
+markdown==3.3.7
     # via tensorboard
-numpy==1.22.3
+numpy==1.23.0
     # via
     #   h5py
     #   keras-preprocessing
@@ -67,7 +67,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-requests==2.27.1
+requests==2.28.1
     # via
     #   requests-oauthlib
     #   tensorboard
@@ -77,14 +77,13 @@ rsa==4.8
     # via google-auth
 six==1.16.0
     # via
-    #   absl-py
     #   astunparse
     #   google-auth
     #   google-pasta
     #   grpcio
     #   keras-preprocessing
     #   tensorflow
-tensorboard==2.8.0
+tensorboard==2.9.1
     # via tensorflow
 tensorboard-data-server==0.6.1
     # via tensorboard
@@ -94,24 +93,24 @@ tensorflow==2.7.0
     # via -r ./batch/docker/tensorflow_requirements.in
 tensorflow-estimator==2.7.0
     # via tensorflow
-tensorflow-io-gcs-filesystem==0.24.0
+tensorflow-io-gcs-filesystem==0.26.0
     # via tensorflow
 termcolor==1.1.0
     # via tensorflow
-typing-extensions==4.1.1
+typing-extensions==4.3.0
     # via tensorflow
-urllib3==1.26.9
+urllib3==1.26.10
     # via requests
-werkzeug==2.0.3
+werkzeug==2.1.2
     # via tensorboard
 wheel==0.37.1
     # via
     #   astunparse
     #   tensorboard
     #   tensorflow
-wrapt==1.14.0
+wrapt==1.14.1
     # via tensorflow
-zipp==3.7.0
+zipp==3.8.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -124,7 +124,7 @@ tqdm==4.64.0
     # via semgrep
 typing-extensions==4.3.0
     # via black
-urllib3==1.26.9
+urllib3==1.26.10
     # via requests
 virtualenv==20.15.1
     # via pre-commit

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ h5py==2.10.0  # Pinned for backwards compatability of our model objects.
 pg8000
 pyparsing
 pystac==0.5.4
-rasterio
+rasterio==1.2.10
 sentry-sdk
 SQLAlchemy
 backoff

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,6 @@ numpy==1.23.0
     #   h5py
     #   pandas
     #   rasterio
-    #   scipy
     #   snuggs
 packaging==21.3
     # via geopandas
@@ -84,8 +83,6 @@ python-dateutil==2.8.2
 pytz==2022.1
     # via pandas
 rasterio==1.2.10
-    # via -r requirements.in
-scipy==1.8.1
     # via -r requirements.in
 scramp==1.4.1
     # via pg8000


### PR DESCRIPTION
Batch model training was failing because of this, by adding scipy explicitly we avoid the dependency wreckage.

Rasterio needs to be pinned for now to 1.2.10 because it is complaining about something something GDAL version.