### PR TITLE
Define BoundLogger in log module

### DIFF
--- a/pixels/generator/generator.py
+++ b/pixels/generator/generator.py
@@ -17,8 +17,7 @@ from pixels.generator.generator_utils import (
     fill_missing_dimensions,
     multiclass_builder,
 )
-from pixels.log import logger
-from pixels.utils import BoundLogger
+from pixels.log import BoundLogger, logger
 
 # Mode Definitions
 GENERATOR_MODE_TRAINING = "training"

--- a/pixels/log.py
+++ b/pixels/log.py
@@ -1,8 +1,58 @@
+import os
 from functools import wraps
+from typing import Dict, Optional
 
-from pixels.utils import BoundLogger
+import structlog
 
-logger = BoundLogger()
+
+class BoundLogger:
+    def __init__(
+        self, bind=None, context: Optional[Dict[str, str]] = None, log_id=None
+    ):
+        """
+        Parameters
+        ----------
+            bind: ref
+                The object to associate the logger with
+            context: dict
+                Contains a dictionary with the human names and
+                the attribute names of the instance that we
+                want to print in every logging message.
+            log_id: str
+                An ID for this logger, generated if None
+        """
+        self.bind = bind or self
+        # Unique and fast id for the instance
+        self.log_id = log_id or os.urandom(4).hex()
+        self.logger = structlog.get_logger(self.log_id)
+
+        self.context = context or {}
+
+        if os.environ.get("AWS_BATCH_JOB_ID"):
+            self.context["AWS_BATCH_JOB_ID"] = os.environ.get("AWS_BATCH_JOB_ID")
+            self.context["AWS_BATCH_JOB_ATTEMPT"] = os.environ.get(
+                "AWS_BATCH_JOB_ATTEMPT"
+            )
+
+    def _log_context(self):
+        context = {"log_id": self.log_id}
+
+        for name, key in self.context.items():
+            context[name] = key
+
+        return context
+
+    def debug(self, message, **kwargs):
+        self.logger.debug(message, **self._log_context(), **kwargs)
+
+    def info(self, message, **kwargs):
+        self.logger.info(message, **self._log_context(), **kwargs)
+
+    def warning(self, message, **kwargs):
+        self.logger.warning(message, **self._log_context(), **kwargs)
+
+    def error(self, message, **kwargs):
+        self.logger.error(message, **self._log_context(), **kwargs)
 
 
 def log_function(func):
@@ -36,3 +86,6 @@ def reset_logger():
     """Creates a new instance of the bound logger."""
     global logger
     logger = BoundLogger()
+
+
+logger = BoundLogger()


### PR DESCRIPTION
We had some cases of circular dependencies because the BoundLogger class was defined in utils, utils was calling tio, and tio was using BoundLogger.