### PR TITLE
Move check_for_squared_pixels to tio.raster

### DIFF
--- a/pixels/generator/stac_utils.py
+++ b/pixels/generator/stac_utils.py
@@ -4,7 +4,6 @@ import rasterio
 from pystac import STAC_IO
 
 from pixels import tio
-from pixels.utils import check_for_squared_pixels
 
 
 def write_method(uri, txt):
@@ -64,7 +63,7 @@ def get_bbox_and_footprint_and_stats(
         Statistics of the data, counts by unique value or histogram.
     """
     with rasterio.open(raster_uri) as ds:
-        check_for_squared_pixels(ds)
+        tio.raster.check_for_squared_pixels(ds)
         # Get bounds.
         bounds = ds.bounds
         # Create bbox as list.

--- a/pixels/tio/raster.py
+++ b/pixels/tio/raster.py
@@ -7,9 +7,14 @@ import numpy as np
 import rasterio
 from rasterio.enums import Resampling
 
+from pixels.exceptions import PixelsException
 from pixels.log import logger
 from pixels.tio.virtual import is_remote, local_or_temp, open_zip, upload
-from pixels.utils import check_for_squared_pixels
+
+
+def check_for_squared_pixels(rst):
+    if abs(rst.transform[0]) != abs(rst.transform[4]):
+        raise PixelsException(f"Pixels are not squared for raster {rst.name}")
 
 
 @dataclass

--- a/pixels/utils.py
+++ b/pixels/utils.py
@@ -18,7 +18,6 @@ from pixels.const import (
     S2_JP2_GOOGLE_FALLBACK_URL_TEMPLATE,
     WORKERS_LIMIT,
 )
-from pixels.exceptions import PixelsException
 
 
 def compute_number_of_pixels(distance: (int, float), scale: (int, float)) -> int:
@@ -247,11 +246,6 @@ def timeseries_steps(start, end, interval, interval_step=1):
         # Increment intermediate timestamps.
         here_start += delta
         here_end += delta
-
-
-def check_for_squared_pixels(rst):
-    if abs(rst.transform[0]) != abs(rst.transform[4]):
-        raise PixelsException(f"Pixels are not squared for raster {rst.name}")
 
 
 class NumpyArrayEncoder(JSONEncoder):


### PR DESCRIPTION
This was moved during the reviews, strictly check_for_squared_pixels does not have io, but it belongs to raster, and here we have not cyclic dependencies.