### PR TITLE
Upload single file or directory contents

### DIFF
--- a/pixels/tio/s3.py
+++ b/pixels/tio/s3.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import shutil
 from typing import AnyStr, List
@@ -16,7 +15,7 @@ class S3:
         self.s3 = boto3.resource("s3")
         self.parsed = urlparse(uri)
         self.bucket = self.parsed.netloc
-        self.key = self.parsed.path[1:]
+        self.key = self.parsed.path.lstrip("/")
         self.requester_pays = (
             "requester" if self.bucket in REQUESTER_PAYS_BUCKETS else ""
         )
@@ -52,8 +51,7 @@ class S3:
     def file_exists(self):
         return self.uri in self.list(suffix="")
 
-    def upload(self, suffix: str, delete_original: bool) -> None:
-        file_list = glob.glob(f"{self.uri}**/**/*{suffix}", recursive=True)
+    def upload(self, file_list: List[str], delete_original: bool) -> None:
         base_dir, bucket, *_ = self.uri.split("/")
         local_start = f"{base_dir}/{bucket}/"
 

--- a/pixels/tio/virtual.py
+++ b/pixels/tio/virtual.py
@@ -124,9 +124,13 @@ def download(uri: str, destination: str) -> str:
 
 def upload(uri: str, suffix: str = "", delete_original=True) -> None:
     """
-    Uploads a file to a specific location based on the uri.
+    Uploads a file or the contents of a dir to a specific location based on the uri.
     """
-    S3(uri).upload(suffix, delete_original)
+    if is_dir(uri):
+        file_list = glob.glob(f"{uri}**/**/*{suffix}", recursive=True)
+    else:
+        file_list = [uri]
+    S3(uri).upload(file_list, delete_original)
 
 
 def load_dictionary(uri: str) -> dict:


### PR DESCRIPTION
This one was _fun_ to catch, we were only uploading things when the provided source was a directory, but it was not working for one single file. This solves many of the Sentry issues currently in pixels, maybe all of them.