### PR TITLE
fix(validator): ensure platform input is always converted to enum members

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -86,7 +86,7 @@ class SearchTest(unittest.TestCase):
             end="2021-01-01",
             maxcloud=100,
             limit=2,
-            platforms="LANDSAT_8",
+            platforms=["LANDSAT_8"],
             bands=["B2", "B4", "B5"],
         )
         actual = search_data(data)


### PR DESCRIPTION
When provided as list, the platform options were kept as plain string.
This was breaking the checking on the search validator.