### PR TITLE
Allow usage of date objects in validators

### DIFF
--- a/pixels/utils.py
+++ b/pixels/utils.py
@@ -221,7 +221,7 @@ def timeseries_steps(start, end, interval, interval_step=1):
     Returns
     -------
     intervals : list of tuples
-        A list of string date tuples. Each tuple is of length two, representing the
+        A list of date tuples. Each tuple is of length two, representing the
         start and end date of a single interval.
     """
     # Convert input into dates if provided as str.
@@ -237,7 +237,7 @@ def timeseries_steps(start, end, interval, interval_step=1):
     here_end = start + delta
     # Loop through timesteps.
     while (here_end - one_day) <= end:
-        yield str(here_start.date()), str((here_end - one_day).date())
+        yield here_start.date(), (here_end - one_day).date()
         # Increment intermediate timestamps.
         here_start += delta
         here_end += delta

--- a/pixels/validators.py
+++ b/pixels/validators.py
@@ -120,8 +120,8 @@ class SearchStacCollectionOption(str, Enum):
 
 class PixelsBaseValidator(BaseModel, extra=Extra.forbid):
     geojson: FeatureCollectionCRS
-    start: Optional[str]
-    end: Optional[str]
+    start: Optional[Union[str, date]]
+    end: Optional[Union[str, date]]
     platforms: Union[
         LandsatPlatform, SentinelPlatform, List[LandsatPlatform], List[SentinelPlatform]
     ]
@@ -132,8 +132,8 @@ class PixelsBaseValidator(BaseModel, extra=Extra.forbid):
 
     @validator("start", "end")
     def is_date(cls, v):
-        date.fromisoformat(v)
-        return v
+        if isinstance(v, date) or date.fromisoformat(v):
+            return v
 
     @validator("platforms")
     def validate_platform_list(cls, v):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import datetime
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -104,8 +105,8 @@ class TestUtils(unittest.TestCase):
 
     def test_timeseries_steps(self):
         expected = [
-            ("2021-01-01", "2021-01-14"),
-            ("2021-01-15", "2021-01-28"),
+            (datetime.date(2021, 1, 1), datetime.date(2021, 1, 14)),
+            (datetime.date(2021, 1, 15), datetime.date(2021, 1, 28)),
         ]
         result = list(timeseries_steps("2021-01-01", "2021-02-01", "weeks", 2))
         self.assertEqual(result, expected)


### PR DESCRIPTION
Ahhh, dates, dates. The previous PR solved something, but we are expecting the objects elsewhere.