### PR TITLE
Import mpire locally inside run_concurrently

### DIFF
--- a/pixels/utils.py
+++ b/pixels/utils.py
@@ -5,7 +5,6 @@ from typing import Any, Iterable, List, Optional
 import numpy
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
-from mpire import WorkerPool
 from rasterio import Affine
 from rasterio.crs import CRS
 from rasterio.features import bounds, rasterize
@@ -364,6 +363,8 @@ def run_concurrently(
             A list with whatever func returned in each call
 
     """
+    from mpire import WorkerPool
+
     if static_arguments:
         iterator = unwrap_arguments([variable_arguments], static_arguments)
     else:


### PR DESCRIPTION
The bug is at import level on the pixels.utils, moving the import to inside the function, that is already the only entrypoint for multiprocessing, we avoid this.