### PR TITLE
feat(generator): add pydantic validator for gen_args

### DIFF
--- a/pixels/generator/stac_training.py
+++ b/pixels/generator/stac_training.py
@@ -20,6 +20,7 @@ from pixels.const import (
 )
 from pixels.generator import generator, losses
 from pixels.generator.stac_utils import plot_history
+from pixels.generator.validators import GeneratorArgumentsValidator
 from pixels.log import log_function, logger
 from pixels.slack import SlackClient
 from pixels.tio.virtual import model_uri
@@ -250,8 +251,8 @@ def train_model_function(
         model : tensorflow trained model
             Model trained with catalog data.
     """
-    # Load the generator arguments.
     gen_args = tio.load_dictionary(generator_arguments_uri)
+    GeneratorArgumentsValidator(**gen_args)
     compile_args = tio.load_dictionary(model_compile_arguments_uri)
     fit_args = tio.load_dictionary(model_fit_arguments_uri)
     path_model = os.path.join(os.path.dirname(model_config_uri), "model.h5")

--- a/pixels/generator/validators.py
+++ b/pixels/generator/validators.py
@@ -1,0 +1,55 @@
+from typing import Optional, Union
+
+from pydantic import BaseModel, Extra, root_validator
+
+from pixels.generator.generator import (
+    GENERATOR_3D_MODEL,
+    GENERATOR_MODE_TRAINING,
+    GENERATOR_PIXEL_MODEL,
+)
+
+
+class GeneratorArgumentsValidator(BaseModel, extra=Extra.forbid):
+    path_collection_catalog: Optional[str] = ""
+    split: Optional[float] = 1
+    random_seed: Optional[float] = None
+    timesteps: Optional[int] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    y_width: Optional[int] = None
+    y_height: Optional[int] = None
+    num_bands: Optional[int] = None
+    num_classes: Optional[int] = 1
+    upsampling: Optional[int] = 1
+    mode: Optional[str] = (GENERATOR_3D_MODEL,)
+    batch_number: Optional[int] = 1
+    padding: Optional[int] = 0
+    y_padding: Optional[int] = 0
+    x_nan_value: Optional[Union[int, float]] = 0
+    y_nan_value: Optional[Union[int, float]] = None
+    nan_value: Optional[Union[int, float]] = None
+    padding_mode: Optional[str] = "edge"
+    dtype: Optional[str] = None
+    augmentation: Optional[int] = 0
+    training_percentage: Optional[float] = 1
+    usage_type: Optional[str] = GENERATOR_MODE_TRAINING
+    class_definitions: Optional[Union[int, list]] = None
+    y_max_value: Optional[Union[int, float]] = None
+    class_weights: Optional[dict] = None
+    download_data: Optional[bool] = False
+    download_dir: Optional[str] = None
+    normalization: Optional[Union[int, float]] = None
+    shuffle: Optional[bool] = True
+    one_hot: Optional[bool] = True
+    cloud_sort: Optional[bool] = False
+    framed_window: Optional[int] = 3
+    train_with_array: Optional[bool] = False
+    eval_split: Optional[float] = 1
+
+    @root_validator(pre=True)
+    def validate_train_with_array_for_1d(cls, values):
+        if values.get("mode", None) == GENERATOR_PIXEL_MODEL and not (
+            values.get("train_with_array", None)
+        ):
+            raise ValueError("Use train_with_array for 1D models")
+        return values

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pixels.generator.generator import DataGenerator
+from pixels.generator.validators import GeneratorArgumentsValidator
 from tests import test_arrays
 
 
@@ -35,6 +36,8 @@ class TestGenerator:
     def test_simple_modes(self, mode, test_tuple):
         gen_args = {**self.gen_args}
         gen_args["mode"] = mode
+        train_with_array = mode == "Pixel_Model"
+        GeneratorArgumentsValidator(**gen_args, train_with_array=train_with_array)
         dtgen = DataGenerator(**gen_args)
         x, y = dtgen[0]
         np.testing.assert_array_equal(x, test_tuple[0])
@@ -54,6 +57,7 @@ class TestGenerator:
         gen_args["augmentation"] = 3
         gen_args["mode"] = mode
         gen_args["batch_number"] = batch
+        GeneratorArgumentsValidator(**gen_args)
         dtgen = DataGenerator(**gen_args)
         x, y = dtgen[0]
         np.testing.assert_array_equal(x, test_tuple[0])
@@ -81,6 +85,7 @@ class TestGenerator:
         gen_args["upsampling"] = 2
         gen_args["mode"] = mode
         gen_args["augmentation"] = augmentation
+        GeneratorArgumentsValidator(**gen_args)
         dtgen = DataGenerator(**gen_args)
         x, y = dtgen[1]
         np.testing.assert_array_equal(x, test_tuple[0])
@@ -101,6 +106,8 @@ class TestGenerator:
         gen_args = {**self.gen_args}
         gen_args["num_classes"] = 3
         gen_args["mode"] = mode
+        train_with_array = mode == "Pixel_Model"
+        GeneratorArgumentsValidator(**gen_args, train_with_array=train_with_array)
         dtgen = DataGenerator(**gen_args)
         x, y = dtgen[2]
         np.testing.assert_array_equal(x, test_tuple[0])
@@ -166,7 +173,8 @@ class TestGenerator:
         gen_args["num_bands"] = num_bands
         gen_args["timesteps"] = timesteps
         gen_args["padding"] = padding
-
+        train_with_array = mode == "Pixel_Model"
+        GeneratorArgumentsValidator(**gen_args, train_with_array=train_with_array)
         dtgen = DataGenerator(**gen_args)
         x, y = dtgen[0]
         np.testing.assert_array_equal(x, test_tuple[0])
@@ -176,9 +184,16 @@ class TestGenerator:
         gen_args = {**self.gen_args}
         dtgen_no_shuffle = DataGenerator(**gen_args)
         gen_args["shuffle"] = True
+        GeneratorArgumentsValidator(**gen_args)
         dtgen = DataGenerator(**gen_args)
         dtgen.on_epoch_end()
         np.testing.assert_array_equal(
             np.sort(dtgen.id_list),
             np.sort(dtgen_no_shuffle.id_list),
         )
+
+    def test_1d_train_with_array_validation_error(self):
+        gen_args = {**self.gen_args}
+        gen_args["mode"] = "Pixel_Model"
+        with pytest.raises(ValueError):
+            GeneratorArgumentsValidator(**gen_args, train_with_array=False)


### PR DESCRIPTION
A minimal version. The goal was to not touch the generator module at all. We can move a lot of constants from the generator into Enums later.