### PR TITLE
Fix batch: do not use latest as tag

### DIFF
--- a/batch/build_ecs_image.sh
+++ b/batch/build_ecs_image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TAG=${1:- "latest"}
+TAG=${1:-"dev"}
 
 cd docker || exit
 
@@ -8,10 +8,11 @@ echo "Logging in external ECS where our base image is"
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
 
 echo "Building the image"
-docker build -t tesselo-pixels .
+docker build -t "tesselo-pixels:$TAG" .
 
 echo "Logging in our private docker repository in AWS"
 aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 595064993071.dkr.ecr.eu-central-1.amazonaws.com
 
 echo "Tagging the newly built image"
-docker tag "tesselo-pixels:$TAG" "595064993071.dkr.ecr.eu-central-1.amazonaws.com/tesselo-pixels:$TAG"
+docker tag "tesselo-pixels:latest" "595064993071.dkr.ecr.eu-central-1.amazonaws.com/tesselo-pixels:$TAG"
+

--- a/batch/update_ecs_image.sh
+++ b/batch/update_ecs_image.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TAG=${1:- "latest"}
+TAG=${1:-"dev"}
 
 ./build_ecs_image.sh "$TAG"
 


### PR DESCRIPTION
Using latest is not good, when we build the production image latest will be automatically tagged in the ECS server.