### PR TITLE
Ignore rasterio fake exceptions

### DIFF
--- a/pixels/tio/virtual.py
+++ b/pixels/tio/virtual.py
@@ -102,11 +102,15 @@ def write(uri: str, content) -> None:
     """
     Writes the content to a file.
     """
-    if is_remote(uri):
-        S3(uri).write(content)
-    else:
-        with open(uri, "w") as file:
-            file.write(content)
+    try:
+        if is_remote(uri):
+            S3(uri).write(content)
+        else:
+            with open(uri, "w") as file:
+                file.write(content)
+    except Exception as e:
+        if not str(e).startswith("File-like object not found in virtual filesystem"):
+            raise e
 
 
 def download(uri: str, destination: str) -> str:


### PR DESCRIPTION
This should solve https://app.asana.com/0/1200802773613549/1201764754534281/f and stop spamming sentry with these fake exceptions. Reducing the log level for rasterio will not work, as they are put into the error level, not info or warning.