### PR TITLE
Silence rasterio fake errors log level

### DIFF
--- a/pixels/__init__.py
+++ b/pixels/__init__.py
@@ -15,5 +15,6 @@ DEBUG = os.environ.get("DEBUG", False)
 configure_structlog(debug=DEBUG, timestamp_format="iso")
 configure_stdlib_logging(debug=DEBUG, timestamp_format="iso", level=logging.INFO)
 
-# Stop the SPAM from botocore
+# Stop the SPAM from botocore and rasterio
 logging.getLogger("botocore.credentials").setLevel(logging.ERROR)
+logging.getLogger("rasterio._filepath").setLevel(logging.CRITICAL + 1)

--- a/pixels/tio/virtual.py
+++ b/pixels/tio/virtual.py
@@ -102,15 +102,11 @@ def write(uri: str, content) -> None:
     """
     Writes the content to a file.
     """
-    try:
-        if is_remote(uri):
-            S3(uri).write(content)
-        else:
-            with open(uri, "w") as file:
-                file.write(content)
-    except Exception as e:
-        if not str(e).startswith("File-like object not found in virtual filesystem"):
-            raise e
+    if is_remote(uri):
+        S3(uri).write(content)
+    else:
+        with open(uri, "w") as file:
+            file.write(content)
 
 
 def download(uri: str, destination: str) -> str:


### PR DESCRIPTION
The other PR didn't work, as rasterio is not creating exceptions, it is sentry the one taking the logging from logging error and sending it to the service. This PR has been tested locally and there is no longer rasterio noize.